### PR TITLE
feat(network): add support for control plane alias IP

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -108,7 +108,7 @@ locals {
   # - The first IP address of your network IP range. For example, in 10.0.0.0/8, you cannot use 10.0.0.1.
   # - The network and broadcast IP addresses of any subnet. For example, in 10.0.0.0/24, you cannot use 10.0.0.0 as well as 10.0.0.255.
   # - The special private IP address 172.31.1.1. This IP address is being used as a default gateway of your server's public network interface.
-  #  control_plane_private_vip_ipv4 = cidrhost(hcloud_network_subnet.nodes.ip_range, 100)
+  control_plane_private_ipv4_vip = cidrhost(hcloud_network_subnet.nodes.ip_range, 100)
   control_plane_private_ipv4_list = [
     for index in range(var.control_plane_count > 0 ? var.control_plane_count : 1) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 101)
   ]

--- a/server.tf
+++ b/server.tf
@@ -53,6 +53,8 @@ resource "hcloud_server" "control_planes" {
   network {
     network_id = hcloud_network_subnet.nodes.network_id
     ip         = local.control_plane_private_ipv4_list[count.index]
+    // only the first control plane gets the VIP
+    alias_ips = count.index == 0 && var.enable_alias_ip ? [local.control_plane_private_ipv4_vip] : []
   }
 
   depends_on = [

--- a/talos.tf
+++ b/talos.tf
@@ -17,8 +17,7 @@ locals {
     compact([
       local.local_api_host,
       local.cluster_api_host,
-      # TODO: not working atm https://github.com/siderolabs/talos/issues/3599
-      #      local.control_plane_private_ipv4_vip,
+      var.enable_alias_ip ? local.control_plane_private_ipv4_vip : null,
       var.enable_floating_ip ? data.hcloud_floating_ip.control_plane_ipv4[0].ip_address : null,
     ])
   )

--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -54,20 +54,19 @@ locals {
                 }
               } : null
             },
-            #            Waiting for https://github.com/siderolabs/talos/pull/8493
-            #            {
-            #              interface = "eth1"
-            #              dhcp      = true
-            #              addresses = [
-            #                local.control_plane_private_ipv4_list[index]
-            #              ]
-            #              vip = {
-            #                ip = local.control_plane_private_ipv4_vip
-            #                hcloud = {
-            #                  apiToken = var.hcloud_token
-            #                }
-            #              }
-            #            }
+            {
+              interface = "eth1"
+              dhcp      = true
+              addresses = [
+                local.control_plane_private_ipv4_list[index]
+              ]
+              vip = var.enable_alias_ip ? {
+                ip = local.control_plane_private_ipv4_vip
+                hcloud = {
+                  apiToken = var.hcloud_token
+                }
+              } : null
+            }
           ]
           extraHostEntries = local.extra_host_entries
           kubespan = {

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "floating_ip" {
   EOF
 }
 
+variable "enable_alias_ip" {
+  type        = bool
+  default     = false
+  description = "If true, an alias IP (cidrhost(node_ipv4_cidr, 100)) will be created and assigned to the control plane nodes."
+}
+
 variable "enable_ipv6" {
   type        = bool
   default     = false


### PR DESCRIPTION
Introduced conditional logic for enabling an alias IP for the control plane, improving network configuration flexibility. This change includes the addition of a new variable `enable_alias_ip` and updates to network and server configurations to conditionally assign the alias IP.