### PR TITLE
feat: Allows specifying the Kubernetes version to use

### DIFF
--- a/talos.tf
+++ b/talos.tf
@@ -35,28 +35,30 @@ locals {
 
 data "talos_machine_configuration" "control_plane" {
   // enable although we have no control planes, to be able to debug the output
-  for_each         = { for control_plane in local.control_planes : control_plane.name => control_plane }
-  talos_version    = var.talos_version
-  cluster_name     = var.cluster_name
-  cluster_endpoint = local.cluster_endpoint
-  machine_type     = "controlplane"
-  machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [yamlencode(local.controlplane_yaml[each.value.name])]
-  docs             = false
-  examples         = false
+  for_each           = { for control_plane in local.control_planes : control_plane.name => control_plane }
+  talos_version      = var.talos_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  kubernetes_version = var.kubernetes_version != null ? var.kubernetes_version : null
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  config_patches     = [yamlencode(local.controlplane_yaml[each.value.name])]
+  docs               = false
+  examples           = false
 }
 
 data "talos_machine_configuration" "worker" {
   // enable although we have no worker, to be able to debug the output
-  for_each         = { for worker in local.workers : worker.name => worker }
-  talos_version    = var.talos_version
-  cluster_name     = var.cluster_name
-  cluster_endpoint = local.cluster_endpoint
-  machine_type     = "worker"
-  machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [yamlencode(local.worker_yaml[each.value.name])]
-  docs             = false
-  examples         = false
+  for_each           = { for worker in local.workers : worker.name => worker }
+  talos_version      = var.talos_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  kubernetes_version = var.kubernetes_version != null ? var.kubernetes_version : null
+  machine_type       = "worker"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  config_patches     = [yamlencode(local.worker_yaml[each.value.name])]
+  docs               = false
+  examples           = false
 }
 
 resource "talos_machine_bootstrap" "this" {

--- a/talos.tf
+++ b/talos.tf
@@ -35,28 +35,30 @@ locals {
 
 data "talos_machine_configuration" "control_plane" {
   // enable although we have no control planes, to be able to debug the output
-  count            = var.control_plane_count > 0 ? var.control_plane_count : 1
-  talos_version    = var.talos_version
-  cluster_name     = var.cluster_name
-  cluster_endpoint = local.cluster_endpoint
-  machine_type     = "controlplane"
-  machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [local.controlplane_yaml[count.index]]
-  docs             = false
-  examples         = false
+  count              = var.control_plane_count > 0 ? var.control_plane_count : 1
+  talos_version      = var.talos_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  kubernetes_version = var.kubernetes_version != null ? var.kubernetes_version : null
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  config_patches     = [local.controlplane_yaml[count.index]]
+  docs               = false
+  examples           = false
 }
 
 data "talos_machine_configuration" "worker" {
   // enable although we have no worker, to be able to debug the output
-  count            = var.worker_count > 0 ? var.worker_count : 1
-  talos_version    = var.talos_version
-  cluster_name     = var.cluster_name
-  cluster_endpoint = local.cluster_endpoint
-  machine_type     = "worker"
-  machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [local.worker_yaml[count.index]]
-  docs             = false
-  examples         = false
+  count              = var.worker_count > 0 ? var.worker_count : 1
+  talos_version      = var.talos_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  kubernetes_version = var.kubernetes_version != null ? var.kubernetes_version : null
+  machine_type       = "worker"
+  machine_secrets    = talos_machine_secrets.this.machine_secrets
+  config_patches     = [local.worker_yaml[count.index]]
+  docs               = false
+  examples           = false
 }
 
 resource "talos_machine_bootstrap" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,12 @@ variable "kube_api_extra_args" {
   description = "Additional arguments to pass to the kube-apiserver."
 }
 
+variable "kubernetes_version" {
+  type        = string
+  default     = null
+  description = "The Kubernetes version to use. If not set, the latest version supported by Talos is used."
+}
+
 variable "kernel_modules_to_load" {
   type = list(object({
     name       = string

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,12 @@ variable "kube_api_extra_args" {
   description = "Additional arguments to pass to the kube-apiserver."
 }
 
+variable "kubernetes_version" {
+  type        = string
+  default     = null
+  description = "The Kubernetes version to use. If not set, the latest version supported by Talos is used."
+}
+
 variable "sysctls_extra_args" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
The `var.kubernetes_version` variable allows specifying the Kubernetes version to use. The version can be specified as string in formats as `1.29.5` or `v1.30.1`. Input is validated by the siderolabs/talos module on apply. By default (unset) the latest Kubernetes version supported by Talos is used.