### PR TITLE
refactor(talos): Use names in patches instead of indexes

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -14,6 +14,20 @@ locals {
   cluster_prefix         = var.cluster_prefix ? "${var.cluster_name}-" : ""
   control_plane_image_id = substr(var.control_plane_server_type, 0, 3) == "cax" ? data.hcloud_image.arm.id : data.hcloud_image.x86.id
   worker_image_id        = substr(var.worker_server_type, 0, 3) == "cax" ? data.hcloud_image.arm.id : data.hcloud_image.x86.id
+  control_planes = [for i in range(var.control_plane_count) : {
+    index       = i
+    name        = "${local.cluster_prefix}control-plane-${i + 1}"
+    ipv4        = local.control_plane_public_ipv4_list[i],
+    ipv6        = var.enable_ipv6 ? local.control_plane_public_ipv6_list[i] : null
+    ipv6_subnet = var.enable_ipv6 ? local.control_plane_public_ipv6_subnet_list[i] : null
+  }]
+  workers = [for i in range(var.worker_count) : {
+    index       = i
+    name        = "${local.cluster_prefix}worker-${i + 1}"
+    ipv4        = local.worker_public_ipv4_list[i],
+    ipv6        = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
+    ipv6_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
+  }]
 }
 
 resource "tls_private_key" "ssh_key" {
@@ -27,12 +41,12 @@ resource "hcloud_ssh_key" "this" {
 }
 
 resource "hcloud_server" "control_planes" {
-  count              = var.control_plane_count
+  for_each           = { for index, control_plane in local.control_planes : control_plane.name => { name = control_plane.name, index = index } }
   datacenter         = data.hcloud_datacenter.this.name
-  name               = "${local.cluster_prefix}control-plane-${count.index + 1}"
+  name               = each.value.name
   image              = local.control_plane_image_id
   server_type        = var.control_plane_server_type
-  user_data          = data.talos_machine_configuration.control_plane[count.index].machine_configuration
+  user_data          = data.talos_machine_configuration.control_plane[each.value.name].machine_configuration
   ssh_keys           = [hcloud_ssh_key.this.id]
   placement_group_id = hcloud_placement_group.control_plane.id
 
@@ -46,14 +60,14 @@ resource "hcloud_server" "control_planes" {
 
   public_net {
     ipv4_enabled = true
-    ipv4         = hcloud_primary_ip.control_plane_ipv4[count.index].id
+    ipv4         = hcloud_primary_ip.control_plane_ipv4[each.value.index].id
     ipv6_enabled = var.enable_ipv6
-    ipv6         = var.enable_ipv6 ? hcloud_primary_ip.control_plane_ipv6[count.index].id : null
+    ipv6         = var.enable_ipv6 ? hcloud_primary_ip.control_plane_ipv6[each.value.index].id : null
   }
 
   network {
     network_id = hcloud_network_subnet.nodes.network_id
-    ip         = local.control_plane_private_ipv4_list[count.index]
+    ip         = local.control_plane_private_ipv4_list[each.value.index]
   }
 
   depends_on = [
@@ -70,12 +84,12 @@ resource "hcloud_server" "control_planes" {
 }
 
 resource "hcloud_server" "workers" {
-  count              = var.worker_count
+  for_each           = { for index, worker in local.workers : worker.name => { name = worker.name, index = index } }
   datacenter         = data.hcloud_datacenter.this.name
-  name               = "${local.cluster_prefix}worker-${count.index + 1}"
+  name               = each.value.name
   image              = local.worker_image_id
   server_type        = var.worker_server_type
-  user_data          = data.talos_machine_configuration.worker[count.index].machine_configuration
+  user_data          = data.talos_machine_configuration.worker[each.value.name].machine_configuration
   ssh_keys           = [hcloud_ssh_key.this.id]
   placement_group_id = hcloud_placement_group.worker.id
 
@@ -89,14 +103,14 @@ resource "hcloud_server" "workers" {
 
   public_net {
     ipv4_enabled = true
-    ipv4         = hcloud_primary_ip.worker_ipv4[count.index].id
+    ipv4         = hcloud_primary_ip.worker_ipv4[each.value.index].id
     ipv6_enabled = var.enable_ipv6
-    ipv6         = var.enable_ipv6 ? hcloud_primary_ip.worker_ipv6[count.index].id : null
+    ipv6         = var.enable_ipv6 ? hcloud_primary_ip.worker_ipv6[each.value.index].id : null
   }
 
   network {
     network_id = hcloud_network_subnet.nodes.network_id
-    ip         = local.worker_private_ipv4_list[count.index]
+    ip         = local.worker_private_ipv4_list[each.value.index]
   }
 
   depends_on = [

--- a/talos.tf
+++ b/talos.tf
@@ -35,26 +35,26 @@ locals {
 
 data "talos_machine_configuration" "control_plane" {
   // enable although we have no control planes, to be able to debug the output
-  count            = var.control_plane_count > 0 ? var.control_plane_count : 1
+  for_each         = { for control_plane in local.control_planes : control_plane.name => control_plane }
   talos_version    = var.talos_version
   cluster_name     = var.cluster_name
   cluster_endpoint = local.cluster_endpoint
   machine_type     = "controlplane"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [local.controlplane_yaml[count.index]]
+  config_patches   = [yamlencode(local.controlplane_yaml[each.value.name])]
   docs             = false
   examples         = false
 }
 
 data "talos_machine_configuration" "worker" {
   // enable although we have no worker, to be able to debug the output
-  count            = var.worker_count > 0 ? var.worker_count : 1
+  for_each         = { for worker in local.workers : worker.name => worker }
   talos_version    = var.talos_version
   cluster_name     = var.cluster_name
   cluster_endpoint = local.cluster_endpoint
   machine_type     = "worker"
   machine_secrets  = talos_machine_secrets.this.machine_secrets
-  config_patches   = [local.worker_yaml[count.index]]
+  config_patches   = [yamlencode(local.worker_yaml[each.value.name])]
   docs             = false
   examples         = false
 }

--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -1,6 +1,6 @@
 locals {
-  controlplane_yaml = [
-    for index in range(0, var.control_plane_count > 0 ? var.control_plane_count : 1) : yamlencode({
+  controlplane_yaml = {
+    for control_plane in local.control_planes : control_plane.name => {
       machine = {
         install = {
           extraKernelArgs = [
@@ -31,8 +31,8 @@ locals {
               interface = "eth0"
               dhcp      = false
               addresses : compact([
-                local.control_plane_public_ipv4_list[index],
-                var.enable_ipv6 ? local.control_plane_public_ipv6_list[index] : null
+                control_plane.ipv4,
+                control_plane.ipv6
               ])
               routes = concat([
                 {
@@ -45,7 +45,7 @@ locals {
                 ],
                 var.enable_ipv6 ? [
                   {
-                    network = local.control_plane_public_ipv6_subnet_list[index]
+                    network = control_plane.ipv6_subnet
                     gateway : "fe80::1"
                   }
                 ] : []
@@ -174,6 +174,6 @@ locals {
           ]
         }
       }
-    })
-  ]
+    }
+  }
 }

--- a/talos_patch_worker.tf
+++ b/talos_patch_worker.tf
@@ -1,6 +1,6 @@
 locals {
-  worker_yaml = [
-    for index in range(0, var.worker_count > 0 ? var.worker_count : 1) : yamlencode({
+  worker_yaml = {
+    for worker in local.workers : worker.name => {
       machine = {
         install = {
           extraKernelArgs = [
@@ -30,8 +30,8 @@ locals {
               interface = "eth0"
               dhcp      = false
               addresses : [
-                local.worker_public_ipv4_list[index],
-                var.enable_ipv6 ? local.worker_public_ipv6_list[index] : null
+                worker.ipv4,
+                worker.ipv6
               ]
               routes = concat([
                 {
@@ -44,7 +44,7 @@ locals {
                 ],
                 var.enable_ipv6 ? [
                   {
-                    network = local.worker_public_ipv6_subnet_list[index]
+                    network = worker.ipv6_subnet
                     gateway : "fe80::1"
                   }
                 ] : []
@@ -90,6 +90,6 @@ locals {
           }
         }
       }
-    })
-  ]
+    }
+  }
 }


### PR DESCRIPTION
This is required to be able to select configs (patches) by name.

You can use `moved` blocks to migrate the servers: e.g.:
```
moved {
  from = module.talos.hcloud_server.control_planes[0]
  to   = module.talos.hcloud_server.control_planes["control-plane-1"]
}
moved {
  from = module.talos.hcloud_server.workers[0]
  to   = module.talos.hcloud_server.workers["worker-1"]
}
```

BREAKING CHANGE: Use `moved` to migrate.