### PR TITLE
feat: Adds labels to hcloud objects

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -78,4 +78,7 @@ resource "hcloud_firewall" "this" {
       source_ips      = lookup(rule.value, "source_ips", [])
     }
   }
+  labels = {
+    "cluster" = var.cluster_name
+  }
 }

--- a/network.tf
+++ b/network.tf
@@ -10,6 +10,9 @@ locals {
 resource "hcloud_network" "this" {
   name     = var.cluster_name
   ip_range = local.network_ipv4_cidr
+  labels = {
+    "cluster" = var.cluster_name
+  }
 }
 
 resource "hcloud_network_subnet" "nodes" {
@@ -30,6 +33,10 @@ resource "hcloud_floating_ip" "control_plane_ipv4" {
   home_location     = data.hcloud_location.this.name
   description       = "Control Plane VIP"
   delete_protection = false
+  labels = {
+    "cluster" = var.cluster_name,
+    "role"    = "control-plane"
+  }
 }
 
 data "hcloud_floating_ip" "control_plane_ipv4" {
@@ -54,6 +61,10 @@ resource "hcloud_primary_ip" "control_plane_ipv4" {
   type          = "ipv4"
   assignee_type = "server"
   auto_delete   = false
+  labels = {
+    "cluster" = var.cluster_name,
+    "role"    = "control-plane"
+  }
 }
 
 resource "hcloud_primary_ip" "control_plane_ipv6" {
@@ -63,6 +74,10 @@ resource "hcloud_primary_ip" "control_plane_ipv6" {
   type          = "ipv6"
   assignee_type = "server"
   auto_delete   = false
+  labels = {
+    "cluster" = var.cluster_name,
+    "role"    = "control-plane"
+  }
 }
 
 resource "hcloud_primary_ip" "worker_ipv4" {
@@ -72,6 +87,10 @@ resource "hcloud_primary_ip" "worker_ipv4" {
   type          = "ipv4"
   assignee_type = "server"
   auto_delete   = false
+  labels = {
+    "cluster" = var.cluster_name,
+    "role"    = "worker"
+  }
 }
 
 resource "hcloud_primary_ip" "worker_ipv6" {
@@ -81,6 +100,10 @@ resource "hcloud_primary_ip" "worker_ipv6" {
   type          = "ipv6"
   assignee_type = "server"
   auto_delete   = false
+  labels = {
+    "cluster" = var.cluster_name,
+    "role"    = "worker"
+  }
 }
 
 locals {

--- a/placement_groups.tf
+++ b/placement_groups.tf
@@ -1,9 +1,15 @@
 resource "hcloud_placement_group" "control_plane" {
   name = "${local.cluster_prefix}control-plane"
   type = "spread"
+  labels = {
+    "cluster" = var.cluster_name
+  }
 }
 
 resource "hcloud_placement_group" "worker" {
   name = "${local.cluster_prefix}worker"
   type = "spread"
+  labels = {
+    "cluster" = var.cluster_name
+  }
 }

--- a/server.tf
+++ b/server.tf
@@ -40,6 +40,9 @@ resource "tls_private_key" "ssh_key" {
 resource "hcloud_ssh_key" "this" {
   name       = "${local.cluster_prefix}default"
   public_key = coalesce(var.ssh_public_key, can(tls_private_key.ssh_key[0].public_key_openssh) ? tls_private_key.ssh_key[0].public_key_openssh : null)
+  labels = {
+    "cluster" = var.cluster_name
+  }
 }
 
 resource "hcloud_server" "control_planes" {
@@ -53,7 +56,8 @@ resource "hcloud_server" "control_planes" {
   placement_group_id = hcloud_placement_group.control_plane.id
 
   labels = {
-    "role" = "control-plane"
+    "cluster" = var.cluster_name,
+    "role"    = "control-plane"
   }
 
   firewall_ids = [
@@ -97,7 +101,8 @@ resource "hcloud_server" "workers" {
   placement_group_id = hcloud_placement_group.worker.id
 
   labels = {
-    "role" = "worker"
+    "cluster" = var.cluster_name,
+    "role"    = "worker"
   }
 
   firewall_ids = [


### PR DESCRIPTION
The labels `cluster` and `role` are added to hcloud objects. Labels can be used as selector in subsequent Terraform resources.