### PR TITLE
fix: Hetzner server type cx11 not available anymore

### DIFF
--- a/_packer/talos-hcloud.pkr.hcl
+++ b/_packer/talos-hcloud.pkr.hcl
@@ -72,7 +72,7 @@ source "hcloud" "talos-x86" {
   rescue       = "linux64"
   image        = "debian-11"
   location     = "${var.server_location}"
-  server_type  = "cx11"
+  server_type  = "cx22"
   ssh_username = "root"
 
   snapshot_name   = "Talos Linux ${var.talos_version} x86 by hcloud-talos"


### PR DESCRIPTION
Hetzner updated their intel cpu lineup. As there is no cx11 server type anymore, it probably should be cx22 as this is the cheapest x86 cloud server type now.
https://www.hetzner.com/cloud/