### PR TITLE
feat(cilium): Added BPF/XDP and support for encryption

### DIFF
--- a/manifest_cilium.tf
+++ b/manifest_cilium.tf
@@ -28,6 +28,22 @@ data "helm_template" "cilium_default" {
     value = "true"
   }
   set {
+    name  = "bpf.masquerade"
+    value = "true"
+  }
+  set {
+    name  = "loadBalancer.acceleration"
+    value = "native"
+  }
+  set {
+    name  = "encryption.enabled"
+    value = var.cilium_enable_encryption ? "true" : "false"
+  }
+  set {
+    name  = "encryption.type"
+    value = "wireguard"
+  }
+  set {
     name  = "securityContext.capabilities.ciliumAgent"
     value = "{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -332,6 +332,12 @@ variable "cilium_values" {
   EOF
 }
 
+variable "cilium_enable_encryption" {
+  type        = bool
+  default     = false
+  description = "Enable transparent network encryption."
+}
+
 variable "cilium_enable_service_monitors" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR adds a few Cilium features to improve the network performance and security:
- Enabled eBPF-based host-routing and masquerading
- Enabled XDP Acceleration for LoadBalancer and NodePort
- Added support for Pod-to-Pod traffic encryption in Cilium

**Before:**
```bash
# kubectl exec -n kube-system ds/cilium -- cilium status --verbose
Host Routing: Legacy
Masquerading: IPTables [IPv4: Enabled, IPv6: Disabled]
[...]
KubeProxyReplacement Details:
  XDP Acceleration: Disabled
[...]
Encryption: Disabled
```

**After:**
```bash
# kubectl exec -n kube-system ds/cilium -- cilium status --verbose
Host Routing: BPF
Masquerading: BPF [eth0, eth1] 10.0.16.0/20 [IPv4: Enabled, IPv6: Disabled]
[...]
KubeProxyReplacement Details:
  XDP Acceleration: Native
[...]
Encryption: Wireguard [NodeEncryption: Disabled, cilium_wg0 (Pubkey: 70TbXMoHvbEtRmsvDck+io/bK1M+QA3y2cBczPWou08=, Port: 51871, Peers: 4)]
```
Info: `endpointRoutes` is excluded here due to https://github.com/cilium/cilium/issues/28812. Additionally, this configuration will automatically become the default in one of the upcoming releases of Cilium (https://github.com/cilium/cilium/issues/14955).

Force Cilium to apply changes: `kubectl -n kube-system rollout restart ds/cilium`