### PR TITLE
Switch to a maintained fork of the kubectl provider

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -23,8 +23,8 @@ terraform {
     }
 
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">=1.14.0"
+      source  = "alekc/kubectl"
+      version = ">=2.0.4"
     }
 
     tls = {


### PR DESCRIPTION
* The alekc/kubectl provider is a maintained fork of gavinbunney/kubectl 
* The alekc/kubectl provider is trusted by both terraform and opentofu