### PR TITLE
feat: output networkID for use with other resources (like LBs)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "public_ipv4_list" {
   description = "List of public IPv4 addresses of all control plane nodes"
   value       = local.control_plane_public_ipv4_list
 }
+
+output "hetzner_network_id" {
+  description = "Network ID of the network created at cluster creation"
+  value       = hcloud_network.this.id
+}


### PR DESCRIPTION
Adding this output allows for automatically associating an Hetzner LB with the talos cluster.