### PR TITLE
fix: renovate dep template for packer dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,7 +57,7 @@
         'version[\\s]+=[\\s]+"(?<currentValue>\\S*)[\\s]+source[\\s]+=[\\s]+"github.com/(?<depName>\\S*)"',
       ],
       datasourceTemplate: 'github-tags',
-      depNameTemplate: '{{#if depName}}{{#if (containsString depName "hashicorp/")}}{{{replace "hashicorp/" "hashicorp/packer-plugin-" depName}}}{{else}}{{{depName}}}{{/if}}{{else}}hashicorp/packer{{/if}}',
+      depNameTemplate: '{{#if depName}}{{#if (containsString depName "hetznercloud/")}}{{{replace "hetznercloud/" "hetznercloud/packer-plugin-" depName}}}{{else}}{{{depName}}}{{/if}}{{else}}hashicorp/packer{{/if}}',
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Use the module as shown in the following working minimal example:
 > Actually, your current IP address has to have access to the nodes during the creation of the cluster.
 
 ```hcl
-module "terraform-hcloud-talos" {
+module "talos" {
   source  = "hcloud-talos/talos/hcloud"
   version = "the-latest-version-of-the-module"
 


### PR DESCRIPTION
Sorry, I made a mistake in my [previous PR](https://github.com/hcloud-talos/terraform-hcloud-talos/pull/100). Hetzner packer plugin is not located under `hashicorp`organisation anymore but under `hetznercloud`.

I also fixed the example in README.

I should have written in my first PR: thanks a lot for all the work!