### PR TITLE
docs(readme): Add helm as Required Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
 
 - [terraform](https://www.terraform.io/downloads.html)
 - [packer](https://www.packer.io/downloads)
+- [helm](https://helm.sh/docs/intro/install/)
+
 
 ### Recommended Software
 


### PR DESCRIPTION
Hey there,

today I made the project run in my environment. But "helm" is also required, otherwise you will get the errors below. After installing "helm" on my machine everything worked.

```
...
Plan: 12 to add, 0 to change, 0 to destroy.
╷
│ Error: no cached repo found. (try 'helm repo update'): open /Users/dennis/Library/Caches/helm/repository/prometheus-community-index.yaml: no such file or directory
│
│   with module.talos.data.helm_template.cilium_default[0],
│   on .terraform/modules/talos/manifest_cilium.tf line 1, in data "helm_template" "cilium_default":
│    1: data "helm_template" "cilium_default" {
│
╵
╷
│ Error: no cached repo found. (try 'helm repo update'): open /Users/dennis/Library/Caches/helm/repository/prometheus-community-index.yaml: no such file or directory
│
│   with module.talos.data.helm_template.hcloud_ccm,
│   on .terraform/modules/talos/manifest_hcloud_ccm.tf line 1, in data "helm_template" "hcloud_ccm":
│    1: data "helm_template" "hcloud_ccm" {
│
╵
```