### PR TITLE
feat(outputs.tf): add compute node ID output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,11 @@ output "hetzner_network_id" {
   description = "Network ID of the network created at cluster creation"
   value       = hcloud_network.this.id
 }
+
+output "talos_worker_ids" {
+  description = "Server IDs of the hetzner talos workers machines"
+  value = {
+    for id, server in hcloud_server.workers : id => server.id
+  }
+}
+


### PR DESCRIPTION
Adding this output allows for attaching volumes to compute nodes for use with a CSI driver such as longhorn. This provides RWM vs the HCloud CSI driver with mounts volumes as RWO.