### PR TITLE
feat(talos): add extraManifests usage via user variable

### DIFF
--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -133,6 +133,7 @@ locals {
             "bind-address" = "0.0.0.0"
           }
         }
+        extraManifests = var.extraManifests
         inlineManifests = [
           {
             name = "hcloud-secret"

--- a/variables.tf
+++ b/variables.tf
@@ -370,3 +370,9 @@ variable "disable_talos_coredns" {
   default     = false
   description = "If true, the CoreDNS delivered by Talos will not be deployed."
 }
+
+variable "extraManifests" {
+  type        = list(string)
+  default     = null
+  description = "Additional manifests URL applied during Talos bootstrap."
+}


### PR DESCRIPTION
add the ability for module users to deploy a given list of manifest URLs. (ex: CD system init)