### PR TITLE
feat(ccm): add toggle variable for hcloud CCM networking feature

### DIFF
--- a/manifest_hcloud_ccm.tf
+++ b/manifest_hcloud_ccm.tf
@@ -9,7 +9,7 @@ data "helm_template" "hcloud_ccm" {
 
   set {
     name  = "networking.enabled"
-    value = "true"
+    value = tostring(var.hcloud_ccm_networking)
   }
 
   set {

--- a/variables.tf
+++ b/variables.tf
@@ -365,6 +365,16 @@ variable "hcloud_ccm_version" {
   description = "The version of the Hetzner Cloud Controller Manager to deploy. If not set, the latest version will be used."
 }
 
+variable "hcloud_ccm_networking" {
+  type        = bool
+  default     = true
+  description = <<EOF
+    Enable Hetzner Cloud Controller Manager networking.
+    If false, pod routing must be handled in some other way. (cilium autoDirectNodeRoutes or BGP)
+    See https://github.com/hetznercloud/hcloud-cloud-controller-manager?tab=readme-ov-file#networks-support
+  EOF
+}
+
 variable "disable_talos_coredns" {
   type        = bool
   default     = false


### PR DESCRIPTION
For my case is to use the 'autoDirectNodeRoutes' cilium features to handle pod routing. And by the way, offer the ability to use cilium IPAM