### PR TITLE
Feature/add ipv6 only support

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="fmt $FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/health.tf
+++ b/health.tf
@@ -9,7 +9,7 @@
 #}
 
 locals {
-  talos_health_endpoint = var.enable_ipv6_only ? "https://${local.control_plane_public_ipv6_list[0]}1:${local.api_port_k8s}": "https://${local.control_plane_public_ipv4_list[0]}:${local.api_port_k8s}"
+  talos_health_endpoint = var.enable_ipv6_only ? "https://[${local.control_plane_public_ipv6_list[0]}1]:${local.api_port_k8s}": "https://${local.control_plane_public_ipv4_list[0]}:${local.api_port_k8s}"
 }
 
 data "http" "talos_health" {

--- a/health.tf
+++ b/health.tf
@@ -8,12 +8,16 @@
 #  worker_nodes         = local.worker_private_ipv4_list
 #}
 
+locals {
+  talos_health_endpoint = var.enable_ipv6_only ? "https://${local.control_plane_public_ipv6_list[0]}1:${local.api_port_k8s}": "https://${local.control_plane_public_ipv4_list[0]}:${local.api_port_k8s}"
+}
+
 data "http" "talos_health" {
   count    = var.control_plane_count > 0 ? 1 : 0
-  url      = "https://${local.control_plane_public_ipv4_list[0]}:${local.api_port_k8s}/version"
+  url      = "${local.talos_health_endpoint}/version"
   insecure = true
   retry {
-    attempts     = 60
+    attempts     = 1
     min_delay_ms = 5000
     max_delay_ms = 5000
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,11 @@ output "public_ipv4_list" {
   value       = local.control_plane_public_ipv4_list
 }
 
+output "public_ipv6_list" {
+  description = "List of public IPv4 addresses of all control plane nodes"
+  value       = local.control_plane_public_ipv6_list
+}
+
 output "hetzner_network_id" {
   description = "Network ID of the network created at cluster creation"
   value       = hcloud_network.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,7 @@ output "kubeconfig" {
 
 output "talos_client_configuration" {
   value = data.talos_client_configuration.this
+  sensitive = true
 }
 
 output "talos_machine_configurations_control_plane" {

--- a/server.tf
+++ b/server.tf
@@ -31,9 +31,9 @@ locals {
     for i in range(var.control_plane_count) : {
       index              = i
       name               = "${local.cluster_prefix}control-plane-${i + 1}"
-      ipv4_public        = local.control_plane_public_ipv4_list[i],
-      ipv6_public        = var.enable_ipv6 ? local.control_plane_public_ipv6_list[i] : null
-      ipv6_public_subnet = var.enable_ipv6 ? local.control_plane_public_ipv6_subnet_list[i] : null
+      ipv4_public        = var.enable_ipv6_only ? null :local.control_plane_public_ipv4_list[i],
+      ipv6_public        = var.enable_ipv6 ? "${local.control_plane_public_ipv6_list[i]}1" : null
+      ipv6_public_subnet = var.enable_ipv6 ? "${local.control_plane_public_ipv6_subnet_list[i]}1" : null
       ipv4_private       = local.control_plane_private_ipv4_list[i]
     }
   ]
@@ -41,8 +41,8 @@ locals {
     for i in range(var.worker_count) : {
       index              = i
       name               = "${local.cluster_prefix}worker-${i + 1}"
-      ipv4_public        = local.worker_public_ipv4_list[i],
-      ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
+      ipv4_public        = var.enable_ipv6_only ? null : local.worker_public_ipv4_list[i],
+      ipv6_public        = var.enable_ipv6 ? "${local.control_plane_public_ipv6_list[i]}1" : null
       ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
       ipv4_private       = local.worker_private_ipv4_list[i]
     }
@@ -82,8 +82,8 @@ resource "hcloud_server" "control_planes" {
   ]
 
   public_net {
-    ipv4_enabled = true
-    ipv4         = hcloud_primary_ip.control_plane_ipv4[each.value.index].id
+    ipv4_enabled = var.enable_ipv6_only ? false : true
+    ipv4         = var.enable_ipv6_only ? null : hcloud_primary_ip.control_plane_ipv4[each.value.index].id
     ipv6_enabled = var.enable_ipv6
     ipv6         = var.enable_ipv6 ? hcloud_primary_ip.control_plane_ipv6[each.value.index].id : null
   }

--- a/talos.tf
+++ b/talos.tf
@@ -171,7 +171,7 @@ locals {
   )
 
   kubeconfig_data = {
-    host                   = "https://${local.best_public_ipv4}:${local.api_port_k8s}"
+    host                   = var.enable_ipv6_only ? local.talos_health_endpoint : "https://${local.best_public_ipv4}:${local.api_port_k8s}"
     cluster_name           = var.cluster_name
     cluster_ca_certificate = var.control_plane_count > 0 ? base64decode(talos_cluster_kubeconfig.this[0].kubernetes_client_configuration.ca_certificate) : tls_self_signed_cert.dummy_ca[0].cert_pem
     client_certificate     = var.control_plane_count > 0 ? base64decode(talos_cluster_kubeconfig.this[0].kubernetes_client_configuration.client_certificate) : tls_locally_signed_cert.dummy_issuer[0].cert_pem

--- a/talos.tf
+++ b/talos.tf
@@ -121,8 +121,8 @@ data "talos_machine_configuration" "dummy_worker" {
 resource "talos_machine_bootstrap" "this" {
   count                = var.control_plane_count > 0 ? 1 : 0
   client_configuration = talos_machine_secrets.this.client_configuration
-  endpoint             = local.control_plane_public_ipv4_list[0]
-  node                 = local.control_plane_public_ipv4_list[0]
+  endpoint             = var.enable_ipv6_only? "${local.control_plane_public_ipv6_list[0]}1" : local.control_plane_public_ipv4_list[0]
+  node                 = var.enable_ipv6_only? "${local.control_plane_public_ipv6_list[0]}1" : local.control_plane_public_ipv4_list[0]
   depends_on = [
     hcloud_server.control_planes
   ]
@@ -152,7 +152,7 @@ data "talos_client_configuration" "this" {
 resource "talos_cluster_kubeconfig" "this" {
   count                = var.control_plane_count > 0 ? 1 : 0
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.control_plane_public_ipv4_list[0]
+  node                 = var.enable_ipv6_only ? "${local.control_plane_public_ipv6_list[0]}1" : local.control_plane_public_ipv4_list[0]
   depends_on = [
     talos_machine_bootstrap.this
   ]

--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -1,4 +1,6 @@
 locals {
+  ipv4_nameservers = var.ipv4_nameservers
+  ipv6_nameservers = var.ipv6_nameservers
   # Define a dummy control plane entry for when count is 0
   dummy_control_planes = var.control_plane_count == 0 ? [{
     index              = 0
@@ -38,6 +40,7 @@ locals {
           }
         }
         network = {
+          nameservers = var.enable_ipv6_only ? var.ipv6_nameservers : var.ipv4_nameservers
           interfaces = [
             {
               interface = "eth0"

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,11 @@ variable "enable_ipv6" {
   EOF
 }
 
+variable "enable_ipv6_only" {
+  type = bool
+  default = false
+}
+
 variable "enable_kube_span" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,16 @@ variable "enable_kube_span" {
   description = "If true, the KubeSpan Feature (with \"Kubernetes registry\" mode) will be enabled."
 }
 
+variable "ipv4_nameservers" {
+  type = list(string)
+  default = ["4.4.4.4", "8.8.8.8"]
+}
+
+variable "ipv6_nameservers" {
+  type = list(string)
+  default = ["2001:4860:4860::8888", "2001:4860:4860::8844"]
+}
+
 variable "network_ipv4_cidr" {
   description = "The main network cidr that all subnets will be created upon."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -154,7 +154,7 @@ variable "ipv4_nameservers" {
 
 variable "ipv6_nameservers" {
   type = list(string)
-  default = ["2001:4860:4860::8888", "2001:4860:4860::8844"]
+  default = ["2a00:1098:2b::1", "2a00:1098:2c::1", "2a01:4f8:c2c:123f::1"] # https://nat64.net/ DNS64 Servers
 }
 
 variable "network_ipv4_cidr" {


### PR DESCRIPTION
## Scenario

In this PR, I'm checking how feasible ipv6 only public network usage is possible on hetzner considering the talos and kubernetes.

At the end, if it works I plan to update the PR items reported by integrations and owners or at least leave the PR as a reference if contributions are not allowed.

I've also commenting some weird or different changes made so I can remember later.

### Step by Step tests and debug

**2025-07-29 16:56 - Initially, I found that with the current tf code the talos control works but not he control-plane.**

Checking with `talosctl dmesg` command, it seems that some remote images that are being hosted on ghcr.io cannot be downloaded on a ipv6 only setup:

```
2a01:4f8:c014:2f4d::1: user: warning: [2025-07-29T16:56:29.297951014Z]: level=info msg=fetch failed error=failed to do request: Head "https://ghcr.io/v2/siderolabs/kubelet/manifests/v1.30.3": dial tcp 140.82.121.34:443: connect: network is unreachable host=ghcr.io image=ghcr.io/siderolabs/kubelet:v1.30.3
2a01:4f8:c014:2f4d::1: user: warning: [2025-07-29T16:56:29.691793014Z]: [talos] controller failed {"component": "controller-runtime", "controller": "k8s.NodeApplyController", "error": "1 error(s) occurred:\n\ttimeout"}
2a01:4f8:c014:2f4d::1: user: warning: [2025-07-29T16:56:31.204434014Z]: [talos] task startAllServices (1/1): service "kubelet" to be "up"
2a01:4f8:c014:2f4d::1: user: warning: [2025-07-29T16:56:35.633225014Z]: [talos] kubernetes endpoint watch error {"component": "controller-runtime", "controller": "k8s.EndpointController", "error": "failed to list *v1.Endpoints: Get \"https://kube.cluster.local:6443/api/v1/namespaces/default/endpoints?fieldSe
```

And since GHCR doesn support ipv6, the following images will not work on a ipv6 only setup considering the default setup: (the list can be obtained using `talosctl image default ` command):

```
ghcr.io/siderolabs/flannel:v0.26.1
gcr.io/etcd-development/etcd:v3.5.17
ghcr.io/siderolabs/kubelet:v1.32.0
ghcr.io/siderolabs/installer:v1.9.0
```
**2025-07-29 Made the kubelet work by using an external NAT64 Service**

UPDATE: After poking around, I found the service `https://nat64.net` so I can test the NAT64 without setting up any additional server... now, it seems that we it worked! At least, `talosctl dashboard` and `kubectl get nodes` are reporting `healthy` status:

<img width="1423" height="580" alt="image" src="https://github.com/user-attachments/assets/ba543514-87f4-4d58-93ed-d194f78a13d9" />
