### PR TITLE
fix: improve alias_ips handling using ignore_changes instead of hardc…

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -91,7 +91,6 @@ resource "hcloud_server" "control_planes" {
   network {
     network_id = hcloud_network_subnet.nodes.network_id
     ip         = each.value.ipv4_private
-    alias_ips  = [] # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
   }
 
   depends_on = [
@@ -102,7 +101,8 @@ resource "hcloud_server" "control_planes" {
   lifecycle {
     ignore_changes = [
       user_data,
-      image
+      image,
+      network.alias_ips # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
     ]
   }
 }
@@ -136,7 +136,6 @@ resource "hcloud_server" "workers" {
   network {
     network_id = hcloud_network_subnet.nodes.network_id
     ip         = each.value.ipv4_private
-    alias_ips  = [] # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
   }
 
   depends_on = [
@@ -147,7 +146,8 @@ resource "hcloud_server" "workers" {
   lifecycle {
     ignore_changes = [
       user_data,
-      image
+      image,
+      network.alias_ips # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
     ]
   }
 }


### PR DESCRIPTION
…oding empty array

Replace hardcoded alias_ips = [] with lifecycle ignore_changes for network.alias_ips to preserve externally-managed IPs while still working around hcloud provider issue
https://github.com/hetznercloud/terraform-provider-hcloud/issues/650.

This prevents alias IPs from being removed on subsequent terraform applies.

Fixes #242

🤖 Generated with [Claude Code](https://claude.ai/code)