### PR TITLE
feat: enable load balancer provisioning on control plane nodes when n…

### DIFF
--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -37,6 +37,11 @@ locals {
             ]
           }
         }
+        nodeLabels = var.worker_count <= 0 ? {
+          "node.kubernetes.io/exclude-from-external-load-balancers" = {
+            "$patch" = "delete"
+          }
+        } : {}
         network = {
           interfaces = [
             {


### PR DESCRIPTION
…o workers exist

Add conditional nodeLabels configuration to remove the exclude-from-external-load-balancers
label from control plane nodes when worker_count <= 0. This allows control plane nodes to receive external load balancer traffic in single-node or control-plane-only clusters while maintaining standard separation for multi-node clusters.

Fixes: #241

🤖 Generated with [Claude Code](https://claude.ai/code)