### PR TITLE
feat: ✨ add support for multiple worker_node types and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,56 @@ module "talos" {
 }
 ```
 
+### Mixed Worker Node Types
+
+For more advanced use cases, you can define different types of worker nodes with individual configurations using the `worker_nodes` variable:
+
+```hcl
+module "talos" {
+  source  = "hcloud-talos/talos/hcloud"
+  version = "<latest-version>"
+
+  talos_version      = "v1.10.3"
+  kubernetes_version = "1.30.3"
+
+  hcloud_token            = "your-hcloud-token"
+  firewall_use_current_ip = true
+
+  cluster_name    = "mixed-cluster"
+  datacenter_name = "fsn1-dc14"
+
+  control_plane_count       = 1
+  control_plane_server_type = "cx22"
+
+  # Define different worker node types
+  worker_nodes = [
+    # Standard x86 workers
+    {
+      type  = "cx22"
+      labels = {
+        "node.kubernetes.io/instance-type" = "cx22"
+      }
+    },
+    # ARM workers for specific workloads
+    {
+      type   = "cax22"
+      labels = {
+        "node.kubernetes.io/arch"          = "arm64"
+        "affinity.example.com" = "example"
+      }
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> The `worker_nodes` variable allows you to:
+> - Mix different server types (x86 and ARM)
+> - Add custom labels to nodes
+> - Control the count of each node type independently
+> 
+> The legacy `worker_count` and `worker_server_type` variables are still supported for backward compatibility but are deprecated in favor of `worker_nodes`.
+
 You need to pipe the outputs of the module:
 
 ```hcl

--- a/README.md
+++ b/README.md
@@ -234,13 +234,20 @@ module "talos" {
         "node.kubernetes.io/instance-type" = "cx22"
       }
     },
-    # ARM workers for specific workloads
+    # ARM workers for specific workloads with taints
     {
       type   = "cax22"
       labels = {
         "node.kubernetes.io/arch"          = "arm64"
         "affinity.example.com" = "example"
       }
+      taints = [
+        {
+          key    = "arm64-only"
+          value  = "true"
+          effect = "NoSchedule"
+        }
+      ]
     }
   ]
 }
@@ -250,6 +257,7 @@ module "talos" {
 > The `worker_nodes` variable allows you to:
 > - Mix different server types (x86 and ARM)
 > - Add custom labels to nodes
+> - Apply taints for workload isolation
 > - Control the count of each node type independently
 > 
 > The legacy `worker_count` and `worker_server_type` variables are still supported for backward compatibility but are deprecated in favor of `worker_nodes`.

--- a/network.tf
+++ b/network.tf
@@ -84,7 +84,7 @@ resource "hcloud_primary_ip" "control_plane_ipv6" {
 }
 
 resource "hcloud_primary_ip" "worker_ipv4" {
-  count         = var.worker_count
+  count         = local.total_worker_count
   name          = "${local.cluster_prefix}worker-${count.index + 1}-ipv4"
   datacenter    = data.hcloud_datacenter.this.name
   type          = "ipv4"
@@ -97,7 +97,7 @@ resource "hcloud_primary_ip" "worker_ipv4" {
 }
 
 resource "hcloud_primary_ip" "worker_ipv6" {
-  count         = var.enable_ipv6 ? var.worker_count > 0 ? var.worker_count : 1 : 0
+  count         = var.enable_ipv6 ? local.total_worker_count > 0 ? local.total_worker_count : 1 : 0
   name          = "${local.cluster_prefix}worker-${count.index + 1}-ipv6"
   datacenter    = data.hcloud_datacenter.this.name
   type          = "ipv6"
@@ -139,6 +139,6 @@ locals {
     for index in range(var.control_plane_count > 0 ? var.control_plane_count : 1) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 101)
   ]
   worker_private_ipv4_list = [
-    for index in range(var.worker_count > 0 ? var.worker_count : 1) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 201)
+    for index in range(local.total_worker_count > 0 ? local.total_worker_count : 1) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 201)
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,7 @@ output "kubeconfig" {
 
 output "talos_client_configuration" {
   value = data.talos_client_configuration.this
+  sensitive = true
 }
 
 output "talos_machine_configurations_control_plane" {
@@ -40,8 +41,9 @@ output "hetzner_network_id" {
 
 output "talos_worker_ids" {
   description = "Server IDs of the hetzner talos workers machines"
-  value = {
-    for id, server in hcloud_server.workers : id => server.id
-  }
+  value = merge(
+    { for id, server in hcloud_server.workers_new : id => server.id},
+    { for id, server in hcloud_server.workers_legacy : id => server.id}
+  )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,7 +43,7 @@ output "talos_worker_ids" {
   description = "Server IDs of the hetzner talos workers machines"
   value = merge(
     { for id, server in hcloud_server.workers_new : id => server.id },
-    { for id, server in hcloud_server.workers_legacy : id => server.id }
+    { for id, server in hcloud_server.workers : id => server.id }
   )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "kubeconfig" {
 }
 
 output "talos_client_configuration" {
-  value = data.talos_client_configuration.this
+  value     = data.talos_client_configuration.this
   sensitive = true
 }
 
@@ -42,8 +42,8 @@ output "hetzner_network_id" {
 output "talos_worker_ids" {
   description = "Server IDs of the hetzner talos workers machines"
   value = merge(
-    { for id, server in hcloud_server.workers_new : id => server.id},
-    { for id, server in hcloud_server.workers_legacy : id => server.id}
+    { for id, server in hcloud_server.workers_new : id => server.id },
+    { for id, server in hcloud_server.workers_legacy : id => server.id }
   )
 }
 

--- a/server.tf
+++ b/server.tf
@@ -22,36 +22,36 @@ locals {
 
   # Calculate total worker count from both old and new variables
   legacy_worker_count = var.worker_count
-  new_worker_count = length(var.worker_nodes)
-  total_worker_count = local.legacy_worker_count + local.new_worker_count
-  
+  new_worker_count    = length(var.worker_nodes)
+  total_worker_count  = local.legacy_worker_count + local.new_worker_count
+
   # Generate worker node configurations from both old and new variables
   legacy_workers = var.worker_count > 0 ? [
     for i in range(var.worker_count) : {
-      index              = i
-      name               = "${local.cluster_prefix}worker-${i + 1}"
-      server_type        = var.worker_server_type
+      index       = i
+      name        = "${local.cluster_prefix}worker-${i + 1}"
+      server_type = var.worker_server_type
       image_id = (
         substr(var.worker_server_type, 0, 3) == "cax" ?
         (var.disable_arm ? null : data.hcloud_image.arm[0].id) :
         (var.disable_x86 ? null : data.hcloud_image.x86[0].id)
       )
-      ipv4_public        = local.worker_public_ipv4_list[i]
-      ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
-      ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
-      ipv4_private       = local.worker_private_ipv4_list[i]
-      labels             = {}
-      node_group_index   = 0
+      ipv4_public         = local.worker_public_ipv4_list[i]
+      ipv6_public         = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
+      ipv6_public_subnet  = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
+      ipv4_private        = local.worker_private_ipv4_list[i]
+      labels              = {}
+      node_group_index    = 0
       node_in_group_index = i
     }
   ] : []
-  
+
 
   new_workers = [
     for i, worker in var.worker_nodes : {
-      index              = local.legacy_worker_count + i
-      name               = "${local.cluster_prefix}worker-${local.legacy_worker_count + i + 1}"
-      server_type        = worker.type
+      index       = local.legacy_worker_count + i
+      name        = "${local.cluster_prefix}worker-${local.legacy_worker_count + i + 1}"
+      server_type = worker.type
       image_id = (
         substr(worker.type, 0, 3) == "cax" ?
         (var.disable_arm ? null : data.hcloud_image.arm[0].id) :
@@ -64,7 +64,7 @@ locals {
       labels             = worker.labels
     }
   ]
-  
+
   # Combine legacy and new workers
   workers = concat(local.legacy_workers, local.new_workers)
 
@@ -149,8 +149,8 @@ resource "hcloud_server" "workers_legacy" {
   placement_group_id = hcloud_placement_group.worker.id
 
   labels = merge({
-    "cluster" = var.cluster_name,
-    "role"    = "worker"
+    "cluster"     = var.cluster_name,
+    "role"        = "worker"
     "server_type" = each.value.server_type
   }, each.value.labels)
 
@@ -197,8 +197,8 @@ resource "hcloud_server" "workers_new" {
   placement_group_id = hcloud_placement_group.worker.id
 
   labels = merge({
-    "cluster" = var.cluster_name,
-    "role"    = "worker"
+    "cluster"     = var.cluster_name,
+    "role"        = "worker"
     "server_type" = each.value.server_type
   }, each.value.labels)
 

--- a/server.tf
+++ b/server.tf
@@ -140,7 +140,7 @@ resource "hcloud_server" "control_planes" {
   }
 }
 
-resource "hcloud_server" "workers_legacy" {
+resource "hcloud_server" "workers" {
   for_each           = { for worker in local.legacy_workers : worker.name => worker }
   datacenter         = data.hcloud_datacenter.this.name
   name               = each.value.name

--- a/server.tf
+++ b/server.tf
@@ -19,14 +19,55 @@ locals {
     (var.disable_arm ? null : data.hcloud_image.arm[0].id) : // Use ARM image if not disabled
     (var.disable_x86 ? null : data.hcloud_image.x86[0].id)   // Use x86 image if not disabled
   )
-  worker_image_id = (
-    var.worker_count > 0 ? # Only calculate if workers exist
-    (
-      substr(var.worker_server_type, 0, 3) == "cax" ?
-      (var.disable_arm ? null : data.hcloud_image.arm[0].id) : // Use ARM image if not disabled
-      (var.disable_x86 ? null : data.hcloud_image.x86[0].id)   // Use x86 image if not disabled
-    ) : null                                                   # No workers, no image needed
-  )
+
+  # Calculate total worker count from both old and new variables
+  legacy_worker_count = var.worker_count
+  new_worker_count = length(var.worker_nodes)
+  total_worker_count = local.legacy_worker_count + local.new_worker_count
+  
+  # Generate worker node configurations from both old and new variables
+  legacy_workers = var.worker_count > 0 ? [
+    for i in range(var.worker_count) : {
+      index              = i
+      name               = "${local.cluster_prefix}worker-${i + 1}"
+      server_type        = var.worker_server_type
+      image_id = (
+        substr(var.worker_server_type, 0, 3) == "cax" ?
+        (var.disable_arm ? null : data.hcloud_image.arm[0].id) :
+        (var.disable_x86 ? null : data.hcloud_image.x86[0].id)
+      )
+      ipv4_public        = local.worker_public_ipv4_list[i]
+      ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
+      ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
+      ipv4_private       = local.worker_private_ipv4_list[i]
+      labels             = {}
+      node_group_index   = 0
+      node_in_group_index = i
+    }
+  ] : []
+  
+
+  new_workers = [
+    for i, worker in var.worker_nodes : {
+      index              = local.legacy_worker_count + i
+      name               = "${local.cluster_prefix}worker-${local.legacy_worker_count + i + 1}"
+      server_type        = worker.type
+      image_id = (
+        substr(worker.type, 0, 3) == "cax" ?
+        (var.disable_arm ? null : data.hcloud_image.arm[0].id) :
+        (var.disable_x86 ? null : data.hcloud_image.x86[0].id)
+      )
+      ipv4_public        = local.worker_public_ipv4_list[local.legacy_worker_count + i]
+      ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[local.legacy_worker_count + i] : null
+      ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[local.legacy_worker_count + i] : null
+      ipv4_private       = local.worker_private_ipv4_list[local.legacy_worker_count + i]
+      labels             = worker.labels
+    }
+  ]
+  
+  # Combine legacy and new workers
+  workers = concat(local.legacy_workers, local.new_workers)
+
   control_planes = [
     for i in range(var.control_plane_count) : {
       index              = i
@@ -35,16 +76,6 @@ locals {
       ipv6_public        = var.enable_ipv6 ? local.control_plane_public_ipv6_list[i] : null
       ipv6_public_subnet = var.enable_ipv6 ? local.control_plane_public_ipv6_subnet_list[i] : null
       ipv4_private       = local.control_plane_private_ipv4_list[i]
-    }
-  ]
-  workers = [
-    for i in range(var.worker_count) : {
-      index              = i
-      name               = "${local.cluster_prefix}worker-${i + 1}"
-      ipv4_public        = local.worker_public_ipv4_list[i],
-      ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[i] : null
-      ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
-      ipv4_private       = local.worker_private_ipv4_list[i]
     }
   ]
 }
@@ -107,20 +138,69 @@ resource "hcloud_server" "control_planes" {
   }
 }
 
-resource "hcloud_server" "workers" {
-  for_each           = { for worker in local.workers : worker.name => worker }
+resource "hcloud_server" "workers_legacy" {
+  for_each           = { for worker in local.legacy_workers : worker.name => worker }
   datacenter         = data.hcloud_datacenter.this.name
   name               = each.value.name
-  image              = local.worker_image_id
-  server_type        = var.worker_server_type
+  image              = each.value.image_id
+  server_type        = each.value.server_type
   user_data          = data.talos_machine_configuration.worker[each.value.name].machine_configuration
   ssh_keys           = [hcloud_ssh_key.this.id]
   placement_group_id = hcloud_placement_group.worker.id
 
-  labels = {
+  labels = merge({
     "cluster" = var.cluster_name,
     "role"    = "worker"
+    "server_type" = each.value.server_type
+  }, each.value.labels)
+
+  firewall_ids = [
+    hcloud_firewall.this.id
+  ]
+
+  public_net {
+    ipv4_enabled = true
+    ipv4         = hcloud_primary_ip.worker_ipv4[each.value.index].id
+    ipv6_enabled = var.enable_ipv6
+    ipv6         = var.enable_ipv6 ? hcloud_primary_ip.worker_ipv6[each.value.index].id : null
   }
+
+  network {
+    network_id = hcloud_network_subnet.nodes.network_id
+    ip         = each.value.ipv4_private
+    alias_ips  = [] # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
+  }
+
+  depends_on = [
+    hcloud_network_subnet.nodes,
+    data.talos_machine_configuration.worker
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      user_data,
+      image
+    ]
+  }
+}
+
+
+
+resource "hcloud_server" "workers_new" {
+  for_each           = { for worker in local.new_workers : worker.name => worker }
+  datacenter         = data.hcloud_datacenter.this.name
+  name               = each.value.name
+  image              = each.value.image_id
+  server_type        = each.value.server_type
+  user_data          = data.talos_machine_configuration.worker[each.value.name].machine_configuration
+  ssh_keys           = [hcloud_ssh_key.this.id]
+  placement_group_id = hcloud_placement_group.worker.id
+
+  labels = merge({
+    "cluster" = var.cluster_name,
+    "role"    = "worker"
+    "server_type" = each.value.server_type
+  }, each.value.labels)
 
   firewall_ids = [
     hcloud_firewall.this.id

--- a/server.tf
+++ b/server.tf
@@ -41,6 +41,7 @@ locals {
       ipv6_public_subnet  = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i] : null
       ipv4_private        = local.worker_private_ipv4_list[i]
       labels              = {}
+      taints              = []
       node_group_index    = 0
       node_in_group_index = i
     }
@@ -62,6 +63,7 @@ locals {
       ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[local.legacy_worker_count + i] : null
       ipv4_private       = local.worker_private_ipv4_list[local.legacy_worker_count + i]
       labels             = worker.labels
+      taints             = worker.taints
     }
   ]
 

--- a/talos.tf
+++ b/talos.tf
@@ -103,20 +103,7 @@ data "talos_machine_configuration" "dummy_control_plane" {
   examples           = false
 }
 
-# Dummy configuration generated when worker_count is 0 for debugging purposes
-# tflint-ignore: terraform_unused_declarations
-data "talos_machine_configuration" "dummy_worker" {
-  count              = var.worker_count == 0 ? 1 : 0
-  talos_version      = var.talos_version
-  cluster_name       = var.cluster_name
-  cluster_endpoint   = local.cluster_endpoint_url_internal # Uses dummy endpoint when count is 0
-  kubernetes_version = var.kubernetes_version
-  machine_type       = "worker"
-  machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches     = concat([yamlencode(local.worker_yaml["dummy-worker-0"])], var.talos_worker_extra_config_patches) # Use dummy yaml + extra patches
-  docs               = false
-  examples           = false
-}
+
 
 resource "talos_machine_bootstrap" "this" {
   count                = var.control_plane_count > 0 ? 1 : 0

--- a/talos_patch_worker.tf
+++ b/talos_patch_worker.tf
@@ -1,21 +1,21 @@
 locals {
   # Define a dummy worker entry for when count is 0
   dummy_workers = local.total_worker_count == 0 ? [{
-    index              = 0
-    name               = "dummy-worker-0"
-    server_type        = "cx11"
-    image_id           = null
-    ipv4_public        = "0.0.0.0"                           # Fallback
-    ipv6_public        = null                                # Fallback
-    ipv6_public_subnet = null                                # Fallback
-    ipv4_private       = cidrhost(local.node_ipv4_cidr, 200) # Use a predictable dummy private IP
-    labels             = {}
-    node_group_index   = 0
+    index               = 0
+    name                = "dummy-worker-0"
+    server_type         = "cx11"
+    image_id            = null
+    ipv4_public         = "0.0.0.0"                           # Fallback
+    ipv6_public         = null                                # Fallback
+    ipv6_public_subnet  = null                                # Fallback
+    ipv4_private        = cidrhost(local.node_ipv4_cidr, 200) # Use a predictable dummy private IP
+    labels              = {}
+    node_group_index    = 0
     node_in_group_index = 0
   }] : []
 
   # Combine real and dummy workers - always include dummy when no workers exist
-#  merged_workers = local.total_worker_count == 0 ? local.dummy_workers : local.workers
+  #  merged_workers = local.total_worker_count == 0 ? local.dummy_workers : local.workers
   merged_workers = concat(local.workers, local.dummy_workers)
 
   # Generate YAML for all (real or dummy) workers

--- a/talos_patch_worker.tf
+++ b/talos_patch_worker.tf
@@ -1,15 +1,21 @@
 locals {
   # Define a dummy worker entry for when count is 0
-  dummy_workers = var.worker_count == 0 ? [{
+  dummy_workers = local.total_worker_count == 0 ? [{
     index              = 0
     name               = "dummy-worker-0"
+    server_type        = "cx11"
+    image_id           = null
     ipv4_public        = "0.0.0.0"                           # Fallback
     ipv6_public        = null                                # Fallback
     ipv6_public_subnet = null                                # Fallback
     ipv4_private       = cidrhost(local.node_ipv4_cidr, 200) # Use a predictable dummy private IP
+    labels             = {}
+    node_group_index   = 0
+    node_in_group_index = 0
   }] : []
 
-  # Combine real and dummy workers
+  # Combine real and dummy workers - always include dummy when no workers exist
+#  merged_workers = local.total_worker_count == 0 ? local.dummy_workers : local.workers
   merged_workers = concat(local.workers, local.dummy_workers)
 
   # Generate YAML for all (real or dummy) workers
@@ -70,6 +76,7 @@ locals {
             "time.cloudflare.com"
           ]
         }
+        nodeLabels = worker.labels
         registries = var.registries
       }
       cluster = {
@@ -88,4 +95,5 @@ locals {
       }
     }
   }
+  value = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -281,7 +281,7 @@ variable "worker_nodes" {
     error_message = "Invalid worker server type in worker_nodes."
   }
   validation {
-    condition = length(var.worker_nodes) <= 99
+    condition     = length(var.worker_nodes) <= 99
     error_message = "Total number of worker nodes must be less than 100."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -218,7 +218,7 @@ variable "control_plane_server_type" {
 variable "worker_count" {
   type        = number
   default     = 0
-  description = "The number of worker nodes to create. Maximum 99."
+  description = "DEPRECATED: Use worker_nodes instead. The number of worker nodes to create. Maximum 99."
   validation {
     condition     = var.worker_count <= 99
     error_message = "The number of worker nodes must be less than 100."
@@ -229,7 +229,7 @@ variable "worker_server_type" {
   type        = string
   default     = "cx11"
   description = <<EOF
-    The server type to use for the worker nodes.
+    DEPRECATED: Use worker_nodes instead. The server type to use for the worker nodes.
     Possible values: cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31,
     cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63
   EOF
@@ -241,6 +241,48 @@ variable "worker_server_type" {
       "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"
     ], var.worker_server_type)
     error_message = "Invalid worker server type."
+  }
+}
+
+variable "worker_nodes" {
+  type = list(object({
+    type   = string
+    labels = optional(map(string), {})
+  }))
+  default     = []
+  description = <<EOF
+    List of worker node configurations. Each object defines a group of worker nodes with the same configuration.
+    - type: Server type (cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31, cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63)
+    - count: Number of nodes of this type
+    - labels: Map of Kubernetes labels to apply to these nodes (default: {})
+    
+    Example:
+    worker_nodes = [
+      {
+        type  = "cx22"
+      },
+      {
+        type   = "cax22"
+        labels = {
+          "node.kubernetes.io/arch" = "arm64"
+        }
+      }
+    ]
+  EOF
+  validation {
+    condition = alltrue([
+      for node in var.worker_nodes : contains([
+        "cx11", "cx21", "cx22", "cx31", "cx32", "cx41", "cx42", "cx51", "cx52",
+        "cpx11", "cpx21", "cpx31", "cpx41", "cpx51",
+        "cax11", "cax21", "cax31", "cax41",
+        "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"
+      ], node.type)
+    ])
+    error_message = "Invalid worker server type in worker_nodes."
+  }
+  validation {
+    condition = length(var.worker_nodes) <= 99
+    error_message = "Total number of worker nodes must be less than 100."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -248,6 +248,11 @@ variable "worker_nodes" {
   type = list(object({
     type   = string
     labels = optional(map(string), {})
+    taints = optional(list(object({
+      key    = string
+      value  = string
+      effect = string
+    })), [])
   }))
   default     = []
   description = <<EOF
@@ -255,6 +260,7 @@ variable "worker_nodes" {
     - type: Server type (cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31, cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63)
     - count: Number of nodes of this type
     - labels: Map of Kubernetes labels to apply to these nodes (default: {})
+    - taints: List of Kubernetes taints to apply to these nodes (default: [])
     
     Example:
     worker_nodes = [
@@ -266,6 +272,13 @@ variable "worker_nodes" {
         labels = {
           "node.kubernetes.io/arch" = "arm64"
         }
+        taints = [
+          {
+            key    = "workload-type"
+            value  = "gpu"
+            effect = "NoSchedule"
+          }
+        ]
       }
     ]
   EOF


### PR DESCRIPTION
# Why
I want to cut costs for everyone by supporting different kind of nodes.

Users of the Cluster might use NodeAffinities tied to node labels to schedule their arm64/amd64 workloads to the individual nodes.

I would have included taints as well, but I couldn't find talos documentation for it.
Maybe you have some ideas.

# How to expand from here

Having support for legacy module syntax is important.
We could uniform the way control-plane-nodes are configured as well.

We could add some additional information in the worker_nodes like additional placement_groups or specific patches.

We could provide static names / ids, for preexisting worker / control planes to adopt a cluster. 


# Key Changes Made

1. New Variable Structure `variables.tf`
Added a new worker_nodes variable that accepts a list of worker node configurations
Each worker node group can specify:
type: Server type (cx22, cax22, etc.)
labels: Kubernetes labels to apply (optional)
> **Kept the old worker_count and worker_server_type variables for backward compatibility (marked as deprecated)**

2. Enhanced Server Logic `server.tf`
Backward Compatibility: The module now supports both old and new variable formats simultaneously
Mixed Architecture Support: Automatically detects ARM vs x86 server types and uses appropriate images
Individual Configuration: Each worker node can have different server types, and labels
Smart Indexing: Maintains proper indexing for IP addresses and naming across both legacy and new workers


3. Network Updates `network.tf`
Updated IP allocation to handle the total count from both legacy and new worker configurations
Maintains proper IP address assignment for all worker nodes regardless of configuration method

4. Talos Configuration `talos_patch_worker.tf`
Per-Node Labels: Each worker node can have custom Kubernetes labels
Flexible Configuration: Supports both simple and complex worker node setups