### PR TITLE
feat: Support Cilium Gateway API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
 > [!IMPORTANT]  
 > The Cilium version (`cilium_version`) has to be compatible with the Kubernetes (`kubernetes_version`) version.
 
+
+#### Cilium Gateway API
+To use Cilium as [Gateway API](https://gateway-api.sigs.k8s.io/) implementation, set `cilium_enable_gateway_api`
+variable. This will install the required dependencies. When you configure a gateway later on, the Cilium operator
+will provision an hcloud Load Balancer using Hcloud Controller Manager.
+> [!IMPORTANT] 
+> This step will fail if the load balancer
+> is not configured with the right [annotations](https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/docs/guides/load-balancer/quickstart.md) 
+> and the gateway will not provision endpoints.
+
+
 ### [Hcloud Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager)
 
 - Updates the `Node` objects with information about the server from the Cloud , like instance Type, Location,

--- a/variables.tf
+++ b/variables.tf
@@ -405,6 +405,18 @@ variable "cilium_version" {
   EOF
 }
 
+variable "cilium_enable_gateway_api" {
+  type        = bool
+  default     = false
+  description = <<EOF
+    If true, the Gateway API will be enabled by:
+    - Installing preqreuisite CRDs https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/
+    - Installing tlsroute CRD
+    - Enabling Gateway API
+    This variable is incompatible with `cilium_values`. If the latter is set, this variable isn't used
+  EOF
+}
+
 variable "cilium_values" {
   type        = list(string)
   default     = null


### PR DESCRIPTION
## Context
The high-level intent behind [this](https://github.com/hcloud-talos/terraform-hcloud-talos/issues/278) issue was to make it easy for a user of this library to use Cilium as Gateway API implementation. The suggestion was to allow customising cilium configuration without having to add a lot of boilerplate.
On further experimenting, this approach wouldn't scale well as:
1. Enabling gateway API involves setting a collection of flags and installing dependencies
2. If cilium was installed (with gateway enabled) before dependencies are installed, gateways wouldn't work even if the dependencies were installed later. This is because the Cilium operator doesn't continuously reconcile.

## Proposition
I think we should either make cilium configuration easily editable (as proposed in the initial issue) or abstract away features through variables. Given the above, this PR proposes the latter option and uses that to support Cilium Gateway API.

NOTE: We install the experimental yaml and not the main yaml as the former includes tlsroute CRDs which are required for the Gateway API regardless of whether it uses TLS or not.