### PR TITLE
feat(control-plane): add `control_plane_allow_schedule` to optionally schedule workloads on CP nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ module "talos" {
 
   control_plane_count       = 3
   control_plane_server_type = "cax11"
+  control_plane_allow_schedule = true
 
   worker_count       = 3
   worker_server_type = "cax21"

--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -109,7 +109,7 @@ locals {
         registries = var.registries
       }
       cluster = {
-        allowSchedulingOnControlPlanes = var.worker_count <= 0
+        allowSchedulingOnControlPlanes = var.control_plane_allow_schedule || var.worker_count <= 0
         network = {
           dnsDomain = var.cluster_domain
           podSubnets = [

--- a/variables.tf
+++ b/variables.tf
@@ -215,6 +215,22 @@ variable "control_plane_server_type" {
   }
 }
 
+
+variable "control_plane_allow_schedule" {
+  type = bool
+  default = false
+  description = <<EOF
+    If true, control plane nodes will be schedulable (i.e., can run workloads).
+    If false (default), control plane nodes will be tainted to prevent scheduling of regular workloads.
+    Note: If you set worker_count to 0, control plane nodes will automatically be schedulable regardless of this setting.
+  EOF
+  validation {
+    condition = var.control_plane_allow_schedule || var.worker_count > 0 || length(var.worker_nodes) > 0
+    error_message = "Control plane nodes cannot be unschedulable when there are no worker nodes."
+  }
+}
+
+
 variable "worker_count" {
   type        = number
   default     = 0

--- a/variables.tf
+++ b/variables.tf
@@ -217,17 +217,13 @@ variable "control_plane_server_type" {
 
 
 variable "control_plane_allow_schedule" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = <<EOF
     If true, control plane nodes will be schedulable (i.e., can run workloads).
     If false (default), control plane nodes will be tainted to prevent scheduling of regular workloads.
     Note: If you set worker_count to 0, control plane nodes will automatically be schedulable regardless of this setting.
   EOF
-  validation {
-    condition = var.control_plane_allow_schedule || var.worker_count > 0 || length(var.worker_nodes) > 0
-    error_message = "Control plane nodes cannot be unschedulable when there are no worker nodes."
-  }
 }
 
 


### PR DESCRIPTION
# Summary
Let me schedule pods on control-plane nodes **even when workers exist**, behind an explicit flag.  
Previously the module only auto-enabled CP scheduling when there were **no** workers. The README even calls that out (“allows scheduling pods on the control planes if no workers are created”). This PR keeps that behavior **and** adds an opt-in switch for mixed clusters.

# What changed
- **New variable** `control_plane_allow_schedule` (default: `false`)
- **Talos patch:**  
  `allowSchedulingOnControlPlanes = var.control_plane_allow_schedule || var.worker_count <= 0`
- **README:** example updated to show the new input

# Why
- Real clusters sometimes need to run light control-plane-friendly workloads (operators, DNS, tiny system apps) on CP nodes for resilience or cost reasons.  
- Today, the module only allows CP scheduling when `worker_count == 0`. That’s too rigid; give users a switch while keeping safe defaults.  
- Defaults remain unchanged → **no breaking changes**.

# Backwards compatibility
- **No behavior change by default.**  
- Existing “no workers → schedule on CP” logic remains intact via `|| var.worker_count <= 0`.

# Inputs
```hcl
variable "control_plane_allow_schedule" {
  type        = bool
  default     = false
  description = <<EOF
    If true, control plane nodes will be schedulable (i.e., can run workloads).
    If false (default), control plane nodes will be tainted to prevent scheduling of regular workloads.
    Note: If you set worker_count to 0, control plane nodes will automatically be schedulable regardless of this setting.
  EOF
}
```

# Example Usage

## Simple using default
``` hcl
module "talos" {
  source = "hcloud-talos/talos/hcloud"

  control_plane_count         = 3
  control_plane_server_type   = "cax11"
  # default false: CPs tainted, workloads land on workers
}
```

## Allow Scheduling explicitly
``` hcl
module "talos" {
  source = "hcloud-talos/talos/hcloud"

  control_plane_count             = 3
  control_plane_server_type       = "cax11"
  control_plane_allow_schedule    = true

  worker_count       = 3
  worker_server_type = "cax21"
}
```

## With No Worker Nodes -> still auto schedulable
``` hcl
module "talos" {
  source = "hcloud-talos/talos/hcloud"

  control_plane_count           = 1
  control_plane_server_type     = "cax11"

  worker_count = 0 # CPs auto-schedulable via existing logic
}
```

# Risk / TradeOFf
- Users can shoot themselves in the foot if they turn this on and then cram heavy workloads onto the CP. That’s on them; the default remains safe.
- `|| var.worker_count <= 0` protects the “no workers & unschedulable CP” dead-end.


# Checklist:
 - [x] Conventional commit title for semantic-release
 - [x] Defaults preserved
 - [x] Var docs + examples updated
