### PR TITLE
feat: add tailscale integration

### DIFF
--- a/.idea/hcloud-talos.iml
+++ b/.idea/hcloud-talos.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
 - [Validates and approves node CSRs](https://github.com/siderolabs/talos-cloud-controller-manager?tab=readme-ov-file#node-certificate-approval).
 - In DaemonSet mode: CCM will use hostNetwork and current node to access kubernetes/talos API
 
+### [Tailscale](https://tailscale.com/) (Optional)
+
+- The Talos Image **MUST** be created with the [tailscale extension](https://github.com/siderolabs/extensions/blob/main/network/tailscale/README.md) when `tailscale.enabled` is set to true.
+- Tailscale can be enabled as a system extension on all nodes
+- Provides secure, encrypted networking between your nodes and other devices in your Tailscale network
+- Makes cluster nodes accessible via their Tailscale IPs from anywhere
+- Requires a valid Tailscale auth key to be provided in the configuration
+
 ## Prerequisites
 
 ### Required Software
@@ -202,6 +210,12 @@ module "talos" {
   node_ipv4_cidr    = "10.0.1.0/24"
   pod_ipv4_cidr     = "10.0.16.0/20"
   service_ipv4_cidr = "10.0.8.0/21"
+  
+  # Enable Tailscale integration
+  tailscale = {
+    enabled  = true
+    auth_key = "tskey-auth-xxxxxxxxxxxx" # Your Tailscale auth key
+  }
 }
 ```
 
@@ -290,6 +304,27 @@ Remember to move the generated config files to a persistent location if needed (
 e.g., `~/.kube/config`, `~/.talos/config`).
 
 ## Additional Configuration Examples
+
+### Tailscale Integration
+
+This module supports configuring Tailscale on your cluster nodes, which provides secure networking capabilities:
+
+```hcl
+tailscale = {
+  enabled  = true
+  auth_key = "tskey-auth-xxxxxxxxxxxx" # Your Tailscale auth key
+}
+```
+
+When Tailscale is enabled:
+- Each node will run Tailscale as a system extension
+- Nodes will automatically connect to your Tailscale network
+- Cilium's loadBalancer acceleration is set to "best-effort" mode for compatibility with Tailscale
+- You can access your cluster nodes directly via their Tailscale IPs
+
+> [!NOTE]
+> You must provide a valid Tailscale auth key when enabling this feature. Auth keys can be generated in the Tailscale admin console.
+> For more information, see the [Tailscale documentation on authentication keys](https://tailscale.com/kb/1085/auth-keys/).
 
 ### Kubelet Extra Args
 

--- a/manifest_cilium.tf
+++ b/manifest_cilium.tf
@@ -8,7 +8,7 @@ data "helm_template" "cilium_default" {
   version      = var.cilium_version
   kube_version = var.kubernetes_version
 
-  set = [
+  set = concat([
     {
       name  = "operator.replicas"
       value = var.control_plane_count > 1 ? 2 : 1
@@ -34,8 +34,10 @@ data "helm_template" "cilium_default" {
       value = "false"
     },
     {
+      // tailscale does not support XDP and therefore native fails. with best-effort we can fallthrough without failing!
+      // see more: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#loadbalancer-nodeport-xdp-acceleration
       name  = "loadBalancer.acceleration"
-      value = "native"
+      value = var.tailscale.enabled ? "best-effort" : "native"
     },
     {
       name  = "encryption.enabled"
@@ -84,8 +86,10 @@ data "helm_template" "cilium_default" {
     {
       name  = "operator.prometheus.serviceMonitor.enabled"
       value = var.cilium_enable_service_monitors ? "true" : "false"
-    }
-  ]
+    },
+    ],
+  )
+
 }
 
 data "helm_template" "cilium_from_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -374,6 +374,23 @@ variable "talos_worker_extra_config_patches" {
   description = "List of additional YAML configuration patches to apply to the Talos machine configuration for worker nodes."
 }
 
+
+variable "tailscale" {
+  type = object({
+    enabled  = optional(bool)
+    auth_key = optional(string)
+  })
+  default = {
+    enabled  = false
+    auth_key = ""
+  }
+  description = "The auth key to use for Tailscale."
+  validation {
+    condition     = var.tailscale.enabled == false || (var.tailscale.enabled == true && var.tailscale.auth_key != "")
+    error_message = "If tailscale is enabled, an auth_key must be provided."
+  }
+}
+
 variable "registries" {
   type = object({
     mirrors = optional(map(object({


### PR DESCRIPTION
# feat(tailscale): ✨ add tailscale configuration

## Description

This PR adds Tailscale integration to the terraform-hcloud-talos module. It includes the necessary configuration for enabling Tailscale as a system extension on all cluster nodes, providing secure networking capabilities between nodes and other devices in a Tailscale network.


## Why this matters

I tested a fresh installation of my cluster with only the configured ExtensionServiceConfig as a extra_*_patch.

There are problems, because tailscale doesn't support XDP, and the `native` mode of the cilium agent, makes it crashloop backoff.

After setting it to best-effort it works smoothly. 


### When `native` is enabled:
<img width="1334" height="88" alt="image" src="https://github.com/user-attachments/assets/a891459a-b5b8-4782-aa47-1d8cfc323ceb" />
<img width="2020" height="50" alt="image" src="https://github.com/user-attachments/assets/142fbe9d-cec6-4960-8817-04dddcd1aab8" />


### Tailscale Integration Features

- **Secure Networking**: Provides encrypted, private networking between cluster nodes and other Tailscale devices
- **Remote Access**: Makes cluster nodes accessible via their Tailscale IPs from anywhere
- **Simple Configuration**: Requires only an auth key to enable the integration
- **Cilium Compatibility**: Automatically adjusts Cilium's loadBalancer acceleration to "best-effort" mode for compatibility with Tailscale
- **Extensible Design**: Implementation allows for future enhancements with additional Tailscale configuration options

## Changes

- Add `tailscale_config_patch` in `talos.tf` to configure Tailscale on nodes
- Add `tailscale` variable in `variables.tf` with validation
- Modify Cilium configuration to use "best-effort" loadBalancer acceleration when Tailscale is enabled
- Update README.md with Tailscale documentation:
  - Add Tailscale to "Additional installed software" section
  - Add dedicated "Tailscale Integration" section with configuration examples
  - Update advanced usage example to include Tailscale configuration

## Testing

If you give me green light, I'd add terraform tests, and could adjust the github actions CI to fail on failed `terraform test` executions.


## Checklist

- [x] Code follows the project's coding style
- [x] Documentation has been updated


## Additional Tasks
- [ ] Terraform Tests added
- [ ] Support more env variables stated in the [extensions readme](https://github.com/siderolabs/extensions/blob/main/network/tailscale/README.md) 
- [ ] GH Actions Integration for terraform test 