### PR TITLE
fix: check worker_nodes in scheduling condition

### DIFF
--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -109,7 +109,7 @@ locals {
         registries = var.registries
       }
       cluster = {
-        allowSchedulingOnControlPlanes = var.control_plane_allow_schedule || var.worker_count <= 0
+        allowSchedulingOnControlPlanes = var.control_plane_allow_schedule || (var.worker_count <= 0 && length(var.worker_nodes) <= 0)
         network = {
           dnsDomain = var.cluster_domain
           podSubnets = [


### PR DESCRIPTION
Hey, I noticed the scheduling taint wasn't being applied when i used the new `worker_nodes` input.
Fixed by also checking `worker_nodes` length in the `allowSchedulingOnControlPlanes` condition.
