### PR TITLE
fix: update supported server types

### DIFF
--- a/talos_patch_worker.tf
+++ b/talos_patch_worker.tf
@@ -3,7 +3,7 @@ locals {
   dummy_workers = local.total_worker_count == 0 ? [{
     index               = 0
     name                = "dummy-worker-0"
-    server_type         = "cx11"
+    server_type         = "cpx11"
     image_id            = null
     ipv4_public         = "0.0.0.0"                           # Fallback
     ipv6_public         = null                                # Fallback

--- a/variables.tf
+++ b/variables.tf
@@ -201,15 +201,16 @@ variable "control_plane_server_type" {
   type        = string
   description = <<EOF
     The server type to use for the control plane nodes.
-    Possible values: cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31,
-    cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63
+    Possible values: cpx11, cpx12, cpx21, cpx22, cpx31, cpx32, cpx41, cpx42, cpx51, cpx52, cpx62,
+    cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63,
+    cx22, cx23, cx32, cx33, cx42, cx43, cx52, cx53
   EOF
   validation {
     condition = contains([
-      "cx11", "cx21", "cx22", "cx31", "cx32", "cx41", "cx42", "cx51", "cx52",
-      "cpx11", "cpx21", "cpx31", "cpx41", "cpx51",
+      "cpx11", "cpx12", "cpx21", "cpx22", "cpx31", "cpx32", "cpx41", "cpx42", "cpx51", "cpx52", "cpx62",
       "cax11", "cax21", "cax31", "cax41",
-      "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"
+      "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63",
+      "cx22", "cx23", "cx32", "cx33", "cx42", "cx43", "cx52", "cx53"
     ], var.control_plane_server_type)
     error_message = "Invalid control plane server type."
   }
@@ -239,18 +240,19 @@ variable "worker_count" {
 
 variable "worker_server_type" {
   type        = string
-  default     = "cx11"
+  default     = "cpx11"
   description = <<EOF
     DEPRECATED: Use worker_nodes instead. The server type to use for the worker nodes.
-    Possible values: cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31,
-    cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63
+    Possible values: cpx11, cpx12, cpx21, cpx22, cpx31, cpx32, cpx41, cpx42, cpx51, cpx52, cpx62,
+    cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63,
+    cx22, cx23, cx32, cx33, cx42, cx43, cx52, cx53
   EOF
   validation {
     condition = contains([
-      "cx11", "cx21", "cx22", "cx31", "cx32", "cx41", "cx42", "cx51", "cx52",
-      "cpx11", "cpx21", "cpx31", "cpx41", "cpx51",
+      "cpx11", "cpx12", "cpx21", "cpx22", "cpx31", "cpx32", "cpx41", "cpx42", "cpx51", "cpx52", "cpx62",
       "cax11", "cax21", "cax31", "cax41",
-      "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"
+      "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63",
+      "cx22", "cx23", "cx32", "cx33", "cx42", "cx43", "cx52", "cx53"
     ], var.worker_server_type)
     error_message = "Invalid worker server type."
   }
@@ -269,7 +271,7 @@ variable "worker_nodes" {
   default     = []
   description = <<EOF
     List of worker node configurations. Each object defines a group of worker nodes with the same configuration.
-    - type: Server type (cx11, cx21, cx22, cx31, cx32, cx41, cx42, cx51, cx52, cpx11, cpx21, cpx31, cpx41, cpx51, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63)
+    - type: Server type (cpx11, cpx12, cpx21, cpx22, cpx31, cpx32, cpx41, cpx42, cpx51, cpx52, cpx62, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63, cx22, cx23, cx32, cx33, cx42, cx43, cx52, cx53)
     - count: Number of nodes of this type
     - labels: Map of Kubernetes labels to apply to these nodes (default: {})
     - taints: List of Kubernetes taints to apply to these nodes (default: [])
@@ -297,10 +299,10 @@ variable "worker_nodes" {
   validation {
     condition = alltrue([
       for node in var.worker_nodes : contains([
-        "cx11", "cx21", "cx22", "cx31", "cx32", "cx41", "cx42", "cx51", "cx52",
-        "cpx11", "cpx21", "cpx31", "cpx41", "cpx51",
+        "cpx11", "cpx12", "cpx21", "cpx22", "cpx31", "cpx32", "cpx41", "cpx42", "cpx51", "cpx52", "cpx62",
         "cax11", "cax21", "cax31", "cax41",
-        "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"
+        "ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63",
+        "cx22", "cx23", "cx32", "cx33", "cx42", "cx43", "cx52", "cx53"
       ], node.type)
     ])
     error_message = "Invalid worker server type in worker_nodes."


### PR DESCRIPTION
Resolves #316 
Updated the supported server types to reflect the available server types returned by the hetzner api.
```bash
$ hcloud server-type list     

ID    NAME    CORES   CPU TYPE    ARCHITECTURE   MEMORY     DISK     STORAGE TYPE
22    cpx11   2       shared      x86            2.0 GB     40 GB    local       
23    cpx21   3       shared      x86            4.0 GB     80 GB    local       
24    cpx31   4       shared      x86            8.0 GB     160 GB   local       
25    cpx41   8       shared      x86            16.0 GB    240 GB   local       
26    cpx51   16      shared      x86            32.0 GB    360 GB   local       
45    cax11   2       shared      arm            4.0 GB     40 GB    local       
93    cax21   4       shared      arm            8.0 GB     80 GB    local       
94    cax31   8       shared      arm            16.0 GB    160 GB   local       
95    cax41   16      shared      arm            32.0 GB    320 GB   local       
96    ccx13   2       dedicated   x86            8.0 GB     80 GB    local       
97    ccx23   4       dedicated   x86            16.0 GB    160 GB   local       
98    ccx33   8       dedicated   x86            32.0 GB    240 GB   local       
99    ccx43   16      dedicated   x86            64.0 GB    360 GB   local       
100   ccx53   32      dedicated   x86            128.0 GB   600 GB   local       
101   ccx63   48      dedicated   x86            192.0 GB   960 GB   local       
104   cx22    2       shared      x86            4.0 GB     40 GB    local       
105   cx32    4       shared      x86            8.0 GB     80 GB    local       
106   cx42    8       shared      x86            16.0 GB    160 GB   local       
107   cx52    16      shared      x86            32.0 GB    320 GB   local       
108   cpx12   1       shared      x86            2.0 GB     40 GB    local       
109   cpx22   2       shared      x86            4.0 GB     80 GB    local       
110   cpx32   4       shared      x86            8.0 GB     160 GB   local       
111   cpx42   8       shared      x86            16.0 GB    320 GB   local       
112   cpx52   12      shared      x86            24.0 GB    480 GB   local       
113   cpx62   16      shared      x86            32.0 GB    640 GB   local       
114   cx23    2       shared      x86            4.0 GB     40 GB    local       
115   cx33    4       shared      x86            8.0 GB     80 GB    local       
116   cx43    8       shared      x86            16.0 GB    160 GB   local       
117   cx53    16      shared      x86            32.0 GB    320 GB   local 
```