### PR TITLE
feat(firewall): add support for external firewall reference

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -1,6 +1,6 @@
 # Retrieve the public IP address of the current machine if the firewall should be opened for the current IP
 data "http" "personal_ipv4" {
-  count = var.firewall_use_current_ip ? 1 : 0
+  count = var.firewall_id == null && var.firewall_use_current_ip ? 1 : 0
   url   = "https://ipv4.icanhazip.com"
 
   retry {
@@ -11,7 +11,7 @@ data "http" "personal_ipv4" {
 }
 
 data "http" "personal_ipv6" {
-  count = var.firewall_use_current_ip && var.enable_ipv6 ? 1 : 0
+  count = var.firewall_id == null && var.firewall_use_current_ip && var.enable_ipv6 ? 1 : 0
   url   = "https://ipv6.icanhazip.com"
 
   retry {
@@ -23,7 +23,8 @@ data "http" "personal_ipv6" {
 
 locals {
   # Current IPs list - always includes IPv4, conditionally includes IPv6
-  current_ips = var.firewall_use_current_ip ? concat(
+  # Only computed when firewall is managed by this module
+  current_ips = var.firewall_id == null && var.firewall_use_current_ip ? concat(
     [
       "${chomp(data.http.personal_ipv4[0].response_body)}/32",
     ],
@@ -79,10 +80,14 @@ locals {
 
   # convert the merged list back to a list
   firewall_rules_list = values(local.firewall_rules_merged)
+
+  # Resolved firewall ID to use
+  firewall_id = var.firewall_id != null ? var.firewall_id : try(hcloud_firewall.this[0].id, null)
 }
 
 resource "hcloud_firewall" "this" {
-  name = var.cluster_name
+  count = var.firewall_id == null ? 1 : 0
+  name  = var.cluster_name
   dynamic "rule" {
     for_each = local.firewall_rules_list
     //noinspection HILUnresolvedReference

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "hetzner_network_id" {
   value       = hcloud_network.this.id
 }
 
+output "firewall_id" {
+  description = "ID of the firewall attached to cluster nodes"
+  value       = local.firewall_id
+}
+
 output "talos_worker_ids" {
   description = "Server IDs of the hetzner talos workers machines"
   value = merge(

--- a/server.tf
+++ b/server.tf
@@ -111,7 +111,7 @@ resource "hcloud_server" "control_planes" {
   }
 
   firewall_ids = [
-    hcloud_firewall.this.id
+    local.firewall_id
   ]
 
   public_net {
@@ -157,7 +157,7 @@ resource "hcloud_server" "workers" {
   }, each.value.labels)
 
   firewall_ids = [
-    hcloud_firewall.this.id
+    local.firewall_id
   ]
 
   public_net {
@@ -205,7 +205,7 @@ resource "hcloud_server" "workers_new" {
   }, each.value.labels)
 
   firewall_ids = [
-    hcloud_firewall.this.id
+    local.firewall_id
   ]
 
   public_net {

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,17 @@ variable "output_mode_config_cluster_endpoint" {
 }
 
 # Firewall
+variable "firewall_id" {
+  type        = string
+  default     = null
+  description = <<EOF
+    ID of an existing Hetzner Cloud firewall to use instead of creating one.
+    When set, the module will not create a firewall and will use this ID instead.
+    This is useful to avoid chicken-and-egg issues when your IP changes:
+    manage the firewall externally and pass its ID here.
+  EOF
+}
+
 variable "firewall_use_current_ip" {
   type        = bool
   default     = false


### PR DESCRIPTION
Allow passing an existing hcloud firewall ID via firewall_id variable.  
When set, the module skips firewall creation and uses the provided one. This avoids chicken-and-egg issues when IP changes block API access during refresh.