### PR TITLE
fix: Use unconfigured Helm provider for templates to avoid plan errors.

### DIFF
--- a/manifest_cilium.tf
+++ b/manifest_cilium.tf
@@ -3,6 +3,8 @@ data "helm_template" "cilium_default" {
   name      = "cilium"
   namespace = "kube-system"
 
+  provider = helm.template
+
   repository   = "https://helm.cilium.io"
   chart        = "cilium"
   version      = var.cilium_version
@@ -97,6 +99,8 @@ data "helm_template" "cilium_from_values" {
   name      = "cilium"
   namespace = "kube-system"
 
+  provider = helm.template
+
   repository   = "https://helm.cilium.io"
   chart        = "cilium"
   version      = var.cilium_version
@@ -127,6 +131,8 @@ data "helm_template" "prometheus_operator_crds" {
   repository   = "https://prometheus-community.github.io/helm-charts"
   version      = var.prometheus_operator_crds_version
   kube_version = var.kubernetes_version
+
+  provider = helm.template
 }
 
 data "kubectl_file_documents" "prometheus_operator_crds" {

--- a/manifest_hcloud_ccm.tf
+++ b/manifest_hcloud_ccm.tf
@@ -3,6 +3,8 @@ data "helm_template" "hcloud_ccm" {
   name      = "hcloud-cloud-controller-manager"
   namespace = "kube-system"
 
+  provider = helm.template
+
   repository   = "https://charts.hetzner.cloud"
   chart        = "hcloud-cloud-controller-manager"
   version      = var.hcloud_ccm_version

--- a/terraform.tf
+++ b/terraform.tf
@@ -47,6 +47,11 @@ provider "helm" {
   }
 }
 
+provider "helm" {
+  alias      = "template"
+  kubernetes = {}
+}
+
 provider "kubectl" {
   host                   = local.kubeconfig_data.host
   client_certificate     = local.kubeconfig_data.client_certificate


### PR DESCRIPTION
Context to this pull request can be found in [this issue](https://github.com/hcloud-talos/terraform-hcloud-talos/issues/383)