### PR TITLE
feat: allow to customize packer server type

### DIFF
--- a/_packer/README.md
+++ b/_packer/README.md
@@ -10,6 +10,10 @@ This directory contains Packer configuration to build Talos OS images suitable f
 > # _packer/hcloud.auto.pkrvars.hcl
 > talos_version = "v1.7.0" # Replace with your desired Talos version
 >
+> # Optionally, set custom server type for building snapshot:
+> # server_type_arm = "cax21"
+> # server_type_x86 = "cx33"
+>
 > # Optionally, add custom image URLs if using the Image Factory:
 > # image_url_arm = "https://factory.talos.dev/image/<SCHEMATIC_ID>/<TALOS_VERSION>/hcloud-arm64.raw.xz"
 > # image_url_x86 = "https://factory.talos.dev/image/<SCHEMATIC_ID>/<TALOS_VERSION>/hcloud-amd64.raw.xz"

--- a/_packer/talos-hcloud.pkr.hcl
+++ b/_packer/talos-hcloud.pkr.hcl
@@ -18,6 +18,16 @@ variable "image_url_arm" {
   default = null
 }
 
+variable "server_type_arm" {
+  type    = string
+  default = "cax11"
+}
+
+variable "server_type_x86" {
+  type    = string
+  default = "cx23"
+}
+
 variable "image_url_x86" {
   type    = string
   default = null
@@ -54,7 +64,7 @@ source "hcloud" "talos-arm" {
   rescue       = "linux64"
   image        = "debian-11"
   location     = "${var.server_location}"
-  server_type  = "cax11"
+  server_type  = "${var.server_type_arm}"
   ssh_username = "root"
 
   snapshot_name   = "Talos Linux ${var.talos_version} ARM by hcloud-talos"
@@ -72,7 +82,7 @@ source "hcloud" "talos-x86" {
   rescue       = "linux64"
   image        = "debian-11"
   location     = "${var.server_location}"
-  server_type  = "cx22"
+  server_type  = "${var.server_type_x86}"
   ssh_username = "root"
 
   snapshot_name   = "Talos Linux ${var.talos_version} x86 by hcloud-talos"


### PR DESCRIPTION
This change allows users to customize the server type used for Packer builds.

I was encountering an error when running _packer/create.sh because the default cx22 server type is not available in my account. Making the server type configurable improves flexibility and prevents this issue for users with different availability constraints.