### PR TITLE
feat: separate Talos image selectors

### DIFF
--- a/_packer/create.sh
+++ b/_packer/create.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # This script builds Hetzner Cloud images for Talos using Packer.
+#
+# Usage:
+#   ./create.sh              # Build generic images (no role label)
+#   ./create.sh --roles      # Build role-specific images (control-plane and worker)
+#   ./create.sh control-plane # Build only control-plane images
+#   ./create.sh worker        # Build only worker images
 
 # Exit immediately if a command exits with a non-zero status.
 # Treat unset variables as an error when substituting.
@@ -10,6 +16,19 @@ set -euo pipefail
 command -v packer >/dev/null 2>&1 || {
     echo >&2 "Error: packer is not installed."
     echo >&2 "Install it via https://www.packer.io/downloads or 'brew install packer' on macOS."
+    exit 1
+}
+
+# Check if curl is installed (needed for schematic ID generation)
+command -v curl >/dev/null 2>&1 || {
+    echo >&2 "Error: curl is not installed."
+    exit 1
+}
+
+# Check if jq is installed (needed for parsing schematic response)
+command -v jq >/dev/null 2>&1 || {
+    echo >&2 "Error: jq is not installed."
+    echo >&2 "Install it via 'brew install jq' on macOS or 'apt-get install jq' on Debian/Ubuntu."
     exit 1
 }
 
@@ -35,8 +54,108 @@ cd "$SCRIPT_DIR"
 echo "Initializing Packer..."
 packer init .
 
-echo "Running packer build for talos-hcloud.pkr.hcl..."
-# Build the packer image(s) defined in the current directory
-packer build .
+# Function to get schematic ID from a schematic YAML file
+get_schematic_id() {
+    local schematic_file="$1"
+    if [[ ! -f "$schematic_file" ]]; then
+        echo >&2 "Error: Schematic file not found: $schematic_file"
+        return 1
+    fi
 
-echo "Packer build finished successfully."
+    local response
+    response=$(curl -s -X POST --data-binary "@$schematic_file" https://factory.talos.dev/schematics)
+    local schematic_id
+    schematic_id=$(echo "$response" | jq -r '.id')
+
+    if [[ -z "$schematic_id" || "$schematic_id" == "null" ]]; then
+        echo >&2 "Error: Failed to get schematic ID from factory.talos.dev"
+        echo >&2 "Response: $response"
+        return 1
+    fi
+
+    echo "$schematic_id"
+}
+
+# Function to build images for a specific role
+build_role() {
+    local role="$1"
+    local schematic_file="schematic-${role}.yaml"
+
+    echo ""
+    echo "=========================================="
+    echo "Building images for role: ${role}"
+    echo "=========================================="
+
+    if [[ ! -f "$schematic_file" ]]; then
+        echo >&2 "Error: Schematic file not found: $schematic_file"
+        echo >&2 "Expected file at: ${SCRIPT_DIR}/${schematic_file}"
+        exit 1
+    fi
+
+    echo "Getting schematic ID for ${role} from factory.talos.dev..."
+    local schematic_id
+    schematic_id=$(get_schematic_id "$schematic_file")
+    echo "Schematic ID: ${schematic_id}"
+
+    # Read talos_version: first from hcloud.auto.pkrvars.hcl, then from talos-hcloud.pkr.hcl default
+    local talos_version=""
+    if [[ -f "hcloud.auto.pkrvars.hcl" ]]; then
+        talos_version=$(grep -E '^talos_version\s*=' hcloud.auto.pkrvars.hcl | sed 's/.*=\s*"\(.*\)".*/\1/' || true)
+    fi
+    if [[ -z "$talos_version" && -f "talos-hcloud.pkr.hcl" ]]; then
+        # Extract default value from the Packer file
+        talos_version=$(grep -A2 'variable "talos_version"' talos-hcloud.pkr.hcl | grep 'default' | sed 's/.*=\s*"\(.*\)".*/\1/' || true)
+    fi
+    if [[ -z "$talos_version" ]]; then
+        echo >&2 "Error: Could not determine talos_version. Set it in hcloud.auto.pkrvars.hcl or talos-hcloud.pkr.hcl"
+        exit 1
+    fi
+
+    local image_url_arm="https://factory.talos.dev/image/${schematic_id}/${talos_version}/hcloud-arm64.raw.xz"
+    local image_url_x86="https://factory.talos.dev/image/${schematic_id}/${talos_version}/hcloud-amd64.raw.xz"
+
+    echo "Talos version: ${talos_version}"
+    echo "ARM image URL: ${image_url_arm}"
+    echo "x86 image URL: ${image_url_x86}"
+    echo ""
+
+    packer build \
+        -var "role=${role}" \
+        -var "image_url_arm=${image_url_arm}" \
+        -var "image_url_x86=${image_url_x86}" \
+        .
+
+    echo "Build complete for role: ${role}"
+}
+
+# Main logic
+case "${1:-}" in
+    --roles)
+        # Build both control-plane and worker images
+        build_role "control-plane"
+        build_role "worker"
+        echo ""
+        echo "All role-specific builds completed successfully."
+        ;;
+    control-plane|worker)
+        # Build images for a specific role
+        build_role "$1"
+        ;;
+    "")
+        # Default: build generic images without role label
+        echo "Running packer build for generic images (no role label)..."
+        echo "Tip: Use './create.sh --roles' to build role-specific images for control-plane and worker nodes."
+        echo ""
+        packer build .
+        echo "Packer build finished successfully."
+        ;;
+    *)
+        echo >&2 "Error: Unknown argument: $1"
+        echo >&2 "Usage:"
+        echo >&2 "  ./create.sh              # Build generic images (no role label)"
+        echo >&2 "  ./create.sh --roles      # Build role-specific images (control-plane and worker)"
+        echo >&2 "  ./create.sh control-plane # Build only control-plane images"
+        echo >&2 "  ./create.sh worker        # Build only worker images"
+        exit 1
+        ;;
+esac

--- a/_packer/schematic-control-plane.yaml
+++ b/_packer/schematic-control-plane.yaml
@@ -1,0 +1,9 @@
+# Schematic configuration for control plane nodes.
+# Includes tailscale extension for secure remote access.
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/iscsi-tools
+      - siderolabs/util-linux-tools
+      - siderolabs/binfmt-misc
+      - siderolabs/tailscale

--- a/_packer/schematic-worker.yaml
+++ b/_packer/schematic-worker.yaml
@@ -1,0 +1,8 @@
+# Schematic configuration for worker nodes.
+# Does not include tailscale extension.
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/iscsi-tools
+      - siderolabs/util-linux-tools
+      - siderolabs/binfmt-misc

--- a/variables.tf
+++ b/variables.tf
@@ -338,6 +338,26 @@ variable "disable_arm" {
   description = "If true, arm images will not be used."
 }
 
+variable "control_plane_image_selector" {
+  type        = string
+  default     = "os=talos"
+  description = <<EOF
+    Label selector for control plane Talos images in Hetzner Cloud.
+    Use this to select images with specific extensions (e.g., tailscale).
+    Example: "os=talos,role=control-plane"
+  EOF
+}
+
+variable "worker_image_selector" {
+  type        = string
+  default     = "os=talos"
+  description = <<EOF
+    Label selector for worker node Talos images in Hetzner Cloud.
+    Use this to select different images than control plane nodes.
+    Example: "os=talos,role=worker"
+  EOF
+}
+
 # Talos
 variable "kubelet_extra_args" {
   type        = map(string)


### PR DESCRIPTION
## Issue

Worker nodes with the Tailscale extension installed but missing the ExtensionServiceConfig cause a boot sequence failure and automatic reboot loop. Currently Tailscale configuration is added to the control-plane nodes only, see `talos_machine_configuration` in talos.tf.


Talos Version: v1.12.2
Kubernetes Version: 1.35.0
Cilium Version: 1.18.6

Workers have the tailscale extension installed but no ExtensionServiceConfig for it:

Control plane (working):
`
apiVersion: v1alpha1
kind: ExtensionServiceConfig
name: tailscale
environment:
    - TS_AUTHKEY=tskey-auth-...
`

Workers (broken):
`
(no tailscale config found)
`

`2026/01/30 12:46:23.020163 [talos] task startAllServices (1/1): service "ext-tailscale" to be "up"
2026/01/30 12:46:23.021019 [talos] task startAllServices (1/1): failed: 1 error occurred:
	* context deadline exceeded

2026/01/30 12:46:23.021759 [talos] phase startEverything (9/9): failed
2026/01/30 12:46:23.022017 [talos] boot sequence: failed
`
`
NODE         SERVICE         STATE     LAST CHANGE
10.0.1.100   ext-tailscale   Running   7h25m ago    ← Control plane OK
10.0.1.201   ext-tailscale   Waiting   41m ago      ← Worker stuck
10.0.1.202   ext-tailscale   Waiting   40m ago      ← Worker stuck
`


## Solution
This feature enables using different Talos OS images for control plane and worker nodes, allowing different system extensions per node type.