### PR TITLE
feat(images): support optional Talos image ID overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
 
 ## Usage
 
-### 1. Build Talos Images with Packer
+### 1. Build Talos Images with Packer (Optional)
+
+> [!TIP]
+> You can also use official Hetzner Talos images directly by setting `talos_image_id_x86` and/or `talos_image_id_arm`.
+> Check the Hetzner changelog for current Talos image IDs: https://docs.hetzner.cloud/changelog
 
 Before deploying with Terraform, you need Talos OS images (snapshots) available in your Hetzner Cloud project. This module provides Packer configurations to build these images.
 
@@ -183,6 +187,10 @@ module "talos" {
   version = "<latest-version>" # Replace with the latest version number
 
   talos_version = "v1.12.2" # The version of talos features to use in generated machine configurations
+
+  # Optional: use official Hetzner Talos image IDs (no custom Packer image required)
+  # talos_image_id_x86 = "<x86-image-id>"
+  # talos_image_id_arm = "<arm-image-id>"
 
   hcloud_token            = "your-hcloud-token"
   # If true, the current IP address will be used as the source for the firewall rules.

--- a/variables.tf
+++ b/variables.tf
@@ -437,6 +437,32 @@ variable "disable_arm" {
   description = "If true, arm images will not be used."
 }
 
+variable "talos_image_id_x86" {
+  type        = string
+  default     = null
+  description = <<EOF
+    Optional Hetzner Cloud image ID for x86_64 architecture.
+    If set, this ID is used directly and the module skips the "os=talos" image selector lookup.
+  EOF
+  validation {
+    condition     = var.talos_image_id_x86 == null || can(regex("^[0-9]+$", var.talos_image_id_x86))
+    error_message = "talos_image_id_x86 must be a numeric image ID string (for example: \"122630\") or null."
+  }
+}
+
+variable "talos_image_id_arm" {
+  type        = string
+  default     = null
+  description = <<EOF
+    Optional Hetzner Cloud image ID for arm64 architecture.
+    If set, this ID is used directly and the module skips the "os=talos" image selector lookup.
+  EOF
+  validation {
+    condition     = var.talos_image_id_arm == null || can(regex("^[0-9]+$", var.talos_image_id_arm))
+    error_message = "talos_image_id_arm must be a numeric image ID string (for example: \"122629\") or null."
+  }
+}
+
 # Talos
 variable "kubelet_extra_args" {
   type        = map(string)


### PR DESCRIPTION
Add talos_image_id_x86 and talos_image_id_arm as optional inputs.

When set, the module skips hcloud image selector lookups and uses provided image IDs directly.

When unset, existing os=talos most_recent behavior remains.

Architecture disable flags remain authoritative, so explicit IDs are ignored when that architecture is disabled.

README usage now documents the optional image-ID path.

Closes: #371