### PR TITLE
[codex] Add optional node names

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ module "talos" {
     # Standard x86 workers
     {
       id   = 1
+      name = "stateful-1"
       type = "cx22"
       labels = {
         "node.kubernetes.io/instance-type" = "cx22"
@@ -447,6 +448,11 @@ module "talos" {
 > - Apply taints for workload isolation
 > - Control the number of nodes by adding/removing entries
 > - Keep stable node identity by setting `id` (1..N)
+> - Override the generated Hetzner/Talos/Kubernetes node name by setting `name`
+
+When `name` is omitted, the module keeps the default generated names like `worker-1` or, with `cluster_prefix = true`,
+`<cluster_name>-worker-1`. When `name` is set, it is used as-is and `cluster_prefix` is not added. Custom names must be
+unique across all control plane and worker nodes and must be valid DNS labels.
 
 You need to pipe the outputs of the module:
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,8 @@ module "talos" {
 
 When `name` is omitted, the module keeps the default generated names like `worker-1` or, with `cluster_prefix = true`,
 `<cluster_name>-worker-1`. When `name` is set, it is used as-is and `cluster_prefix` is not added. Custom names must be
-unique across all control plane and worker nodes and must be valid DNS labels.
+unique across all control plane and worker nodes and must be valid DNS labels. The module also renders a Talos
+`HostnameConfig` document for custom names, so Hetzner server names and Talos/Kubernetes node names stay aligned.
 
 You need to pipe the outputs of the module:
 

--- a/server.tf
+++ b/server.tf
@@ -41,7 +41,7 @@ locals {
   control_planes = [
     for i in range(1, local.control_plane_count + 1) : {
       index       = i - 1
-      name        = "${local.cluster_prefix}control-plane-${i}"
+      name        = coalesce(local.control_plane_nodes_by_id[i].name, "${local.cluster_prefix}control-plane-${i}")
       server_type = local.control_plane_nodes_by_id[i].type
       image_id = (
         substr(local.control_plane_nodes_by_id[i].type, 0, 3) == "cax" ?
@@ -65,7 +65,7 @@ locals {
   workers = [
     for i in range(1, local.worker_count + 1) : {
       index       = i - 1
-      name        = "${local.cluster_prefix}worker-${i}"
+      name        = coalesce(local.worker_nodes_by_id[i].name, "${local.cluster_prefix}worker-${i}")
       server_type = local.worker_nodes_by_id[i].type
       image_id = (
         substr(local.worker_nodes_by_id[i].type, 0, 3) == "cax" ?

--- a/server.tf
+++ b/server.tf
@@ -42,6 +42,7 @@ locals {
     for i in range(1, local.control_plane_count + 1) : {
       index       = i - 1
       name        = coalesce(local.control_plane_nodes_by_id[i].name, "${local.cluster_prefix}control-plane-${i}")
+      custom_name = local.control_plane_nodes_by_id[i].name != null
       server_type = local.control_plane_nodes_by_id[i].type
       image_id = (
         substr(local.control_plane_nodes_by_id[i].type, 0, 3) == "cax" ?
@@ -66,6 +67,7 @@ locals {
     for i in range(1, local.worker_count + 1) : {
       index       = i - 1
       name        = coalesce(local.worker_nodes_by_id[i].name, "${local.cluster_prefix}worker-${i}")
+      custom_name = local.worker_nodes_by_id[i].name != null
       server_type = local.worker_nodes_by_id[i].type
       image_id = (
         substr(local.worker_nodes_by_id[i].type, 0, 3) == "cax" ?

--- a/talos.tf
+++ b/talos.tf
@@ -88,9 +88,21 @@ data "talos_machine_configuration" "control_plane" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "controlplane"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches     = concat([yamlencode(local.controlplane_yaml[each.value.name])], var.talos_control_plane_extra_config_patches, local.tailscale_config_patch != null ? [local.tailscale_config_patch] : [])
-  docs               = false
-  examples           = false
+  config_patches = concat(
+    [yamlencode(local.controlplane_yaml[each.value.name])],
+    each.value.custom_name ? [
+      yamlencode({
+        apiVersion = "v1alpha1"
+        kind       = "HostnameConfig"
+        auto       = "off"
+        hostname   = each.value.name
+      })
+    ] : [],
+    var.talos_control_plane_extra_config_patches,
+    local.tailscale_config_patch != null ? [local.tailscale_config_patch] : []
+  )
+  docs     = false
+  examples = false
 }
 
 data "talos_machine_configuration" "worker" {
@@ -101,9 +113,20 @@ data "talos_machine_configuration" "worker" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches     = concat([yamlencode(local.worker_yaml[each.value.name])], var.talos_worker_extra_config_patches)
-  docs               = false
-  examples           = false
+  config_patches = concat(
+    [yamlencode(local.worker_yaml[each.value.name])],
+    each.value.custom_name ? [
+      yamlencode({
+        apiVersion = "v1alpha1"
+        kind       = "HostnameConfig"
+        auto       = "off"
+        hostname   = each.value.name
+      })
+    ] : [],
+    var.talos_worker_extra_config_patches
+  )
+  docs     = false
+  examples = false
 }
 
 resource "talos_machine_bootstrap" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -275,6 +275,7 @@ variable "ssh_public_key" {
 variable "control_plane_nodes" {
   type = list(object({
     id     = number
+    name   = optional(string)
     type   = string
     labels = optional(map(string), {})
     taints = optional(list(object({
@@ -290,6 +291,7 @@ variable "control_plane_nodes" {
     The total number of control planes must be odd (1, 3, 5) and at most 5.
 
     - id: Stable node id starting at 1 (used for naming and IP allocation).
+    - name: Optional custom node name. If omitted, the module uses the default generated name.
     - type: Server type (cpx11, cpx12, cpx21, cpx22, cpx31, cpx32, cpx41, cpx42, cpx51, cpx52, cpx62, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63, cx22, cx23, cx32, cx33, cx42, cx43, cx52, cx53)
     - labels: Map of Kubernetes labels to apply to this node (default: {})
     - taints: List of Kubernetes taints to apply to this node (default: [])
@@ -323,6 +325,15 @@ variable "control_plane_nodes" {
     error_message = "control_plane_nodes id must be unique and contiguous starting at 1 (1..N)."
   }
   validation {
+    condition = alltrue([
+      for node in var.control_plane_nodes : node.name == null || (
+        length(node.name) <= 63 &&
+        length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", node.name)) > 0
+      )
+    ])
+    error_message = "control_plane_nodes name must be a valid DNS label: lowercase alphanumeric characters or hyphens, start and end with an alphanumeric character, and be at most 63 characters."
+  }
+  validation {
     condition = alltrue(flatten([
       for node in var.control_plane_nodes : [
         for taint in node.taints : contains(["NoSchedule", "PreferNoSchedule", "NoExecute"], taint.effect)
@@ -346,6 +357,7 @@ variable "control_plane_allow_schedule" {
 variable "worker_nodes" {
   type = list(object({
     id     = number
+    name   = optional(string)
     type   = string
     labels = optional(map(string), {})
     taints = optional(list(object({
@@ -361,6 +373,7 @@ variable "worker_nodes" {
     Each entry represents one worker node.
 
     - id: Stable node id starting at 1 (used for naming and IP allocation).
+    - name: Optional custom node name. If omitted, the module uses the default generated name.
     - type: Server type (cpx11, cpx12, cpx21, cpx22, cpx31, cpx32, cpx41, cpx42, cpx51, cpx52, cpx62, cax11, cax21, cax31, cax41, ccx13, ccx23, ccx33, ccx43, ccx53, ccx63, cx22, cx23, cx32, cx33, cx42, cx43, cx52, cx53)
     - labels: Map of Kubernetes labels to apply to this node (default: {})
     - taints: List of Kubernetes taints to apply to this node (default: [])
@@ -410,6 +423,32 @@ variable "worker_nodes" {
       )) == 0
     )
     error_message = "worker_nodes id must be unique and contiguous starting at 1 (1..N)."
+  }
+  validation {
+    condition = alltrue([
+      for node in var.worker_nodes : node.name == null || (
+        length(node.name) <= 63 &&
+        length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", node.name)) > 0
+      )
+    ])
+    error_message = "worker_nodes name must be a valid DNS label: lowercase alphanumeric characters or hyphens, start and end with an alphanumeric character, and be at most 63 characters."
+  }
+  validation {
+    condition = length(distinct(concat(
+      [
+        for node in var.control_plane_nodes : coalesce(
+          node.name,
+          var.cluster_prefix ? "${var.cluster_name}-control-plane-${node.id}" : "control-plane-${node.id}"
+        )
+      ],
+      [
+        for node in var.worker_nodes : coalesce(
+          node.name,
+          var.cluster_prefix ? "${var.cluster_name}-worker-${node.id}" : "worker-${node.id}"
+        )
+      ]
+    ))) == length(concat(var.control_plane_nodes, var.worker_nodes))
+    error_message = "Effective node names across control_plane_nodes and worker_nodes must be unique."
   }
   validation {
     condition = alltrue(flatten([


### PR DESCRIPTION
## What changed

- Adds an optional `name` field to `control_plane_nodes` and `worker_nodes`.
- Keeps the existing generated names when `name` is omitted.
- Uses custom names as-is when provided, without adding `cluster_prefix`.
- Validates custom names as DNS labels and checks effective node names are unique across control plane and worker nodes.
- Documents custom node names in the mixed worker node example.

## Why

Some clusters need stable role-oriented node names such as `stateful-1`, `system-1`, or `ci-deploy-1` while still using `id` for stable IP allocation and Terraform identity.

This keeps backward compatibility for existing users and only changes naming when the new optional field is set.

## Validation

- `terraform fmt -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate`
