### PR TITLE
fix: set machine.network.hostname to per-node name

### DIFF
--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -44,6 +44,7 @@ locals {
           } : {}
         )
         network = {
+          hostname = control_plane.name
           interfaces = [
             {
               interface = "eth0"

--- a/talos_patch_worker.tf
+++ b/talos_patch_worker.tf
@@ -36,6 +36,7 @@ locals {
           } : {}
         )
         network = {
+          hostname         = worker.name
           extraHostEntries = local.extra_host_entries
           kubespan = {
             enabled = var.enable_kube_span


### PR DESCRIPTION
## Problem

Talos has no persistent hostname source. The module names each Hetzner server deterministically (`<cluster_prefix>control-plane-<i>`, `<cluster_prefix>worker-<i>`), but the rendered Talos machine config never sets `machine.network.hostname`. After a `talosctl upgrade` reboot (e.g. driven by [tuppr](https://github.com/siderolabs/tuppr)), the node comes up with an auto-generated hostname like `talos-u4e-prh`. kubelet then registers a brand-new `Node` object under that random name, while the original `control-plane-N` / `worker-N` `Node` lingers as `NotReady`.

The cluster ends up with duplicate `Node` objects for the same physical machine, `hcloud-cloud-controller-manager` cannot match the random name to a Hetzner server, and the upgrade reconciler gets stuck.

Hit in production-shaped testing on `v3.2.2`.

## Fix

Pin `machine.network.hostname` to the deterministic per-node name the module already computes, in both per-node patch files where the name is in scope:

- [talos_patch_worker.tf](talos_patch_worker.tf): `hostname = worker.name`
- [talos_patch_control_plane.tf](talos_patch_control_plane.tf): `hostname = control_plane.name`

Two-line change, no other modifications.

## Repro

1. Deploy a cluster with the module (any version up to and including `v3.2.2`).
2. Trigger a Talos upgrade via tuppr or `talosctl upgrade`.
3. Observe `kubectl get nodes` — both the original `control-plane-N` / `worker-N` and a `talos-XXXX-XXX` placeholder will appear, with the original stuck `NotReady`.

## Risk

- **New clusters:** none — the hostname is set on first boot to the same name kubelet would already pick.
- **Existing clusters:** applying the new module version will set the hostname on the next config sync. Nodes that currently rely on an auto-generated name (i.e. nodes that have already drifted post-upgrade) will rename to the deterministic name. This is the desired behavior, but worth calling out — operators may see one `Node` rename event after upgrade.