### PR TITLE
feat(network): add BYO network, VPN route support, and network outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,103 @@ kubeconfig_endpoint_mode   = "public_endpoint"
 talosconfig_endpoints_mode = "public_ip"
 ```
 
+### VPN Site-to-Site (Shared Private Network)
+
+You can attach a VPN gateway VM (from another Terraform module) to the same private network as the cluster, allowing secure access from remote locations without exposing services to the public internet.
+
+**How it works:**
+- The VPN gateway VM gets a private IP in the cluster's node subnet (e.g., `10.0.1.250`)
+- The gateway does SNAT/masquerading for VPN client traffic, so cluster nodes see traffic as originating from the gateway's private IP
+- No extra routes needed on cluster nodes — return traffic goes directly to the gateway on the same subnet
+
+**Pattern A — Reference the network from another module:**
+
+```hcl
+module "cluster" {
+  source  = "hcloud-talos/talos/hcloud"
+  version = "<latest-version>"
+
+  hcloud_token            = "your-hcloud-token"
+  firewall_use_current_ip = true
+  cluster_name            = "vpn-cluster"
+  location_name           = "fsn1"
+
+  control_plane_nodes = [
+    { id = 1, type = "cax11" }
+  ]
+}
+
+# In your VPN gateway module, consume the outputs:
+module "vpn_gateway" {
+  source = "./vpn-gateway"
+
+  hcloud_network_id = module.cluster.hetzner_network_id
+  node_subnet_cidr  = module.cluster.node_ipv4_cidr
+  # Give the VPN gateway a private IP in the same subnet, e.g., 10.0.1.250
+}
+```
+
+**Pattern B — Share a network between cluster and VPN modules (BYO network):**
+
+```hcl
+# Create the shared network once
+resource "hcloud_network" "shared" {
+  name     = "shared-net"
+  ip_range = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "shared" {
+  network_id   = hcloud_network.shared.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+# Pass it to the cluster module
+module "cluster" {
+  source  = "hcloud-talos/talos/hcloud"
+  version = "<latest-version>"
+
+  hcloud_token            = "your-hcloud-token"
+  firewall_use_current_ip = true
+  cluster_name            = "vpn-cluster"
+  location_name           = "fsn1"
+
+  # BYO network: module uses this instead of creating a new one
+  network_id       = hcloud_network.shared.id
+  node_ipv4_cidr   = "10.0.1.0/24" # must match the existing subnet
+
+  control_plane_nodes = [
+    { id = 1, type = "cax11" }
+  ]
+}
+
+# VPN gateway attached to the same network
+module "vpn_gateway" {
+  source = "./vpn-gateway"
+
+  hcloud_network_id = hcloud_network.shared.id
+  node_subnet_cidr  = "10.0.1.0/24"
+}
+```
+
+**Adding network routes for VPN client subnets:**
+
+If you want proper routing (instead of SNAT) between VPN clients and cluster nodes, add static routes to the Hetzner network:
+
+```hcl
+module "cluster" {
+  # ... other settings ...
+
+  network_routes = [
+    {
+      destination = "10.8.0.0/24"   # VPN client subnet
+      gateway     = "10.0.1.250"    # VPN gateway private IP
+    }
+  ]
+}
+```
+
 ### Mixed Worker Node Types
 
 For more advanced use cases, you can define different types of worker nodes with individual configurations using the `worker_nodes` variable:

--- a/network.tf
+++ b/network.tf
@@ -1,13 +1,27 @@
 locals {
   # https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/docs/deploy_with_networks.md#considerations-on-the-ip-ranges
+  create_network           = var.network_id == null
   network_ipv4_cidr        = var.network_ipv4_cidr
   node_ipv4_cidr           = var.node_ipv4_cidr
   node_ipv4_cidr_mask_size = split("/", local.node_ipv4_cidr)[1] # 24
   pod_ipv4_cidr            = var.pod_ipv4_cidr
   service_ipv4_cidr        = var.service_ipv4_cidr
+
+  # Resolved network ID: either the user-provided one or the one created by this module
+  network_id = coalesce(
+    var.network_id,
+    try(hcloud_network.this[0].id, null)
+  )
+
+  # Resolved subnet CIDR for IP allocation: from the managed subnet or the variable
+  node_ipv4_cidr_resolved = coalesce(
+    try(hcloud_network_subnet.nodes[0].ip_range, null),
+    var.node_ipv4_cidr
+  )
 }
 
 resource "hcloud_network" "this" {
+  count    = local.create_network ? 1 : 0
   name     = var.cluster_name
   ip_range = local.network_ipv4_cidr
   labels = {
@@ -16,10 +30,19 @@ resource "hcloud_network" "this" {
 }
 
 resource "hcloud_network_subnet" "nodes" {
-  network_id   = hcloud_network.this.id
+  count        = local.create_network ? 1 : 0
+  network_id   = local.network_id
   type         = "cloud"
   network_zone = data.hcloud_location.selected.network_zone
   ip_range     = local.node_ipv4_cidr
+}
+
+resource "hcloud_network_route" "vpn" {
+  for_each = { for idx, route in var.network_routes : idx => route }
+
+  network_id  = local.network_id
+  destination = each.value.destination
+  gateway     = each.value.gateway
 }
 
 locals {
@@ -133,11 +156,11 @@ locals {
   # - The first IP address of your network IP range. For example, in 10.0.0.0/8, you cannot use 10.0.0.1.
   # - The network and broadcast IP addresses of any subnet. For example, in 10.0.0.0/24, you cannot use 10.0.0.0 as well as 10.0.0.255.
   # - The special private IP address 172.31.1.1. This IP address is being used as a default gateway of your server's public network interface.
-  control_plane_private_vip_ipv4 = cidrhost(hcloud_network_subnet.nodes.ip_range, 100)
+  control_plane_private_vip_ipv4 = cidrhost(local.node_ipv4_cidr_resolved, 100)
   control_plane_private_ipv4_list = [
-    for index in range(local.control_plane_count) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 101)
+    for index in range(local.control_plane_count) : cidrhost(local.node_ipv4_cidr_resolved, index + 101)
   ]
   worker_private_ipv4_list = [
-    for index in range(local.worker_count) : cidrhost(hcloud_network_subnet.nodes.ip_range, index + 201)
+    for index in range(local.worker_count) : cidrhost(local.node_ipv4_cidr_resolved, index + 201)
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,8 +35,23 @@ output "public_ipv4_list" {
 }
 
 output "hetzner_network_id" {
-  description = "Network ID of the network created at cluster creation"
-  value       = hcloud_network.this.id
+  description = "Network ID of the Hetzner Cloud network used by the cluster"
+  value       = local.network_id
+}
+
+output "network_ipv4_cidr" {
+  description = "The main network CIDR that all subnets are created within"
+  value       = local.network_ipv4_cidr
+}
+
+output "node_ipv4_cidr" {
+  description = "The node subnet CIDR used for control plane and worker nodes"
+  value       = local.node_ipv4_cidr
+}
+
+output "network_subnet_id" {
+  description = "Network subnet ID (only set when the module creates the subnet)"
+  value       = local.create_network ? hcloud_network_subnet.nodes[0].id : null
 }
 
 output "firewall_id" {

--- a/server.tf
+++ b/server.tf
@@ -129,7 +129,7 @@ resource "hcloud_server" "control_planes" {
   }
 
   network {
-    network_id = hcloud_network_subnet.nodes.network_id
+    network_id = local.network_id
     ip         = each.value.ipv4_private
     alias_ips  = [] # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
   }
@@ -177,7 +177,7 @@ resource "hcloud_server" "workers" {
   }
 
   network {
-    network_id = hcloud_network_subnet.nodes.network_id
+    network_id = local.network_id
     ip         = each.value.ipv4_private
     alias_ips  = [] # fix for https://github.com/hetznercloud/terraform-provider-hcloud/issues/650
   }

--- a/talos_patch_control_plane.tf
+++ b/talos_patch_control_plane.tf
@@ -168,7 +168,7 @@ locals {
                 name: hcloud
                 namespace: kube-system
               data:
-                network: ${base64encode(hcloud_network.this.id)}
+                network: ${base64encode(local.network_id)}
                 token: ${base64encode(var.hcloud_token)}
             EOT
           }

--- a/variables.tf
+++ b/variables.tf
@@ -254,6 +254,44 @@ variable "service_ipv4_cidr" {
   default     = "10.0.8.0/21"
 }
 
+variable "network_id" {
+  type        = string
+  default     = null
+  description = <<EOF
+    Optional. ID of an existing Hetzner Cloud network to use instead of creating one.
+    When set, the module will not create a new network or subnet — both must already exist.
+    Use this for VPN site-to-site setups where the network is shared between modules
+    (e.g., a separate infra module creates the network, and both the cluster and VPN
+    gateway modules consume it).
+
+    The existing subnet must match `node_ipv4_cidr`.
+  EOF
+
+  validation {
+    condition     = var.network_id == null || try(tonumber(var.network_id), null) != null
+    error_message = "network_id must be a valid Hetzner Cloud network ID (numeric)."
+  }
+}
+
+variable "network_routes" {
+  type = list(object({
+    destination = string
+    gateway     = string
+  }))
+  default     = []
+  description = <<EOF
+    Optional. Network routes to add to the Hetzner Cloud network.
+    Useful for VPN site-to-site setups where VPN clients are in a different subnet.
+    Each route must specify a destination CIDR and a gateway IP (the private IP
+    of the VPN gateway VM within the same network).
+
+    Example:
+    [
+      { destination = "10.8.0.0/24", gateway = "10.0.1.250" }
+    ]
+  EOF
+}
+
 # Server
 variable "talos_version" {
   type        = string


### PR DESCRIPTION
## Summary

Adds VPN site-to-site support by enabling three new capabilities:

### 1. BYO network (`network_id`)
Pass an existing Hetzner Cloud network ID to use instead of creating one. When set, the module skips `hcloud_network` and `hcloud_network_subnet` creation and uses the provided network. This allows sharing a network between the cluster module and a VPN gateway module.

### 2. VPN route support (`network_routes`)
Define static routes via `hcloud_network_route` resources for VPN client subnets (e.g., WireGuard subnets) so traffic can be routed through the VPN gateway without SNAT.

### 3. Extra network outputs
New outputs `network_ipv4_cidr`, `node_ipv4_cidr`, and `network_subnet_id` make it easy for external modules (VPN gateways) to consume network details.

### Files changed
| File | Change |
|---|---|
| `variables.tf` | Added `network_id` and `network_routes` |
| `network.tf` | Conditional network/subnet creation, resolved locals, `hcloud_network_route` resources |
| `server.tf` | Server network attachments use `local.network_id` |
| `talos_patch_control_plane.tf` | CCM secret uses `local.network_id` |
| `outputs.tf` | Added `network_ipv4_cidr`, `node_ipv4_cidr`, `network_subnet_id` |
| `README.md` | VPN Site-to-Site documentation with usage examples |

Closes #419