### PR TITLE
feat(talos): add private bootstrap mode and disable_public_ipv4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
      - The IP of an external TCP load balancer you configure separately (pass-through, no TLS termination).
      - The public IP of a specific control plane node (less recommended for multi-node control planes).
   - The generated `kubeconfig` will use this hostname if `kubeconfig_endpoint_mode = "public_endpoint"`.
-  - The generated `talosconfig` will always use direct per-node IPs as endpoints (see `talosconfig_endpoints_mode`).
+  - The generated `talosconfig` uses direct per-node IPs by default and can optionally use endpoint hostnames via `talosconfig_endpoints_mode`.
   - **Note:** `cluster_api_host` is the Kubernetes API endpoint (TCP/6443). Talos API access uses TCP/50000 and is
     configured separately via `talosconfig_endpoints_mode`.
 - **Internal API Endpoint:**
@@ -75,6 +75,13 @@ This repository contains a Terraform module for creating a Kubernetes cluster wi
     (controlled by `kubeconfig_endpoint_mode`, defaulting to the first control plane's public IP or the Floating IP).
   - `talosconfig` endpoints are configured separately via `talosconfig_endpoints_mode`.
   - Internal communication will still use the internal API hostname (defaults to `kube.[cluster_domain]`) if `enable_alias_ip = true`.
+- **Private Bootstrap (`bootstrap_endpoint_mode`):**
+  - When running Terraform from a host with VPN/private network access (WireGuard, Tailscale, site-to-site VPN),
+    set `bootstrap_endpoint_mode = "private_ip"` so Terraform bootstraps and health-checks the cluster via private IPs
+    instead of public IPs.
+  - Combine with `disable_public_ipv4 = true` to provision nodes without public IPv4 addresses entirely.
+  - See the [WireGuard VPN example](#vpn-only-private-bootstrap-with-wireguard) for a tested setup using Talos's
+    built-in WireGuard.
 
 ## Additional installed software in the cluster
 
@@ -332,19 +339,94 @@ module "talos" {
 
 These snippets show only the endpoint- and access-related settings. Combine them with the required module inputs from the examples above.
 
-#### VPN-only (private kubeconfig/talosconfig)
+#### VPN-only (private bootstrap with WireGuard)
 
-Use this when your workstation/CI reaches the nodes via VPN/private networking, but the public firewall should still allow your current public IP (so Terraform can bootstrap and manage the cluster).
+Use Talos's built-in [WireGuard](https://www.talos.dev/v1.13/networking/advanced/wireguard/) to bootstrap and manage the cluster over private IPs. No site-to-site VPN VM or external DNS needed.
 
+**On the cluster side** (added as a machine config patch):
 ```hcl
-firewall_use_current_ip = true
+talos_control_plane_extra_config_patches = [
+  yamlencode({
+    apiVersion = "v1alpha1"
+    kind       = "WireguardConfig"
+    name       = "wg0"
+    privateKey = "<base64-node-private-key>"
+    listenPort = 51820
+    addresses  = [{ address = "10.200.0.1/24" }]
+    peers = [{
+      publicKey  = "<base64-workstation-public-key>"
+      allowedIPs = ["10.200.0.0/24"]
+    }]
+  })
+]
 
-# Use the private VIP via a VPN-resolvable hostname (split-horizon DNS).
-enable_alias_ip            = true # default
-cluster_api_host_private   = "kube.vpn.example.com" # -> 10.0.1.100 (private VIP)
-kubeconfig_endpoint_mode   = "private_endpoint"
+extra_firewall_rules = [
+  {
+    direction   = "in"
+    protocol    = "udp"
+    port        = "51820"
+    source_ips  = ["0.0.0.0/0"]
+    description = "WireGuard VPN tunnel"
+  }
+]
+```
+
+**On your workstation** (macOS WireGuard app or `wg-quick`):
+```ini
+[Interface]
+PrivateKey = <base64-workstation-private-key>
+Address = 10.200.0.250/24
+
+[Peer]
+PublicKey = <base64-node-public-key>
+Endpoint = <control-plane-public-ip>:51820
+AllowedIPs = 10.200.0.0/24, 10.0.1.0/24
+PersistentKeepalive = 25
+```
+
+Once the tunnel is active, switch to private bootstrap:
+```hcl
+bootstrap_endpoint_mode    = "private_ip"
+kubeconfig_endpoint_mode   = "private_ip"
 talosconfig_endpoints_mode = "private_ip"
 ```
+
+> [!NOTE]
+> - The WireGuard patch is applied at node boot time (part of the Talos machine config).
+> - For the initial deployment, bootstrap still uses public IPs (`bootstrap_endpoint_mode = "public_ip"`, the default).
+> - After nodes boot with the WireGuard interface active, enable private bootstrap for subsequent operations.
+
+#### VPN-only (site-to-site VPN gateway)
+
+Use this when you already have a VPN gateway VM (`10.0.1.250`) on the same private network, or when you have split-horizon DNS resolving `kube.vpn.example.com` to the private VIP (`10.0.1.100`).
+
+```hcl
+enable_alias_ip            = true # default
+cluster_api_host_private   = "kube.vpn.example.com" # -> 10.0.1.100 (private VIP)
+
+bootstrap_endpoint_mode    = "private_ip"
+kubeconfig_endpoint_mode   = "private_ip"  # uses 10.0.1.100 directly
+# kubeconfig_endpoint_mode = "private_endpoint"  # alternative: requires DNS
+
+talosconfig_endpoints_mode = "private_ip"
+
+# Optional: remove public IPv4 entirely
+# disable_public_ipv4      = true
+```
+
+#### Fully Private (no public IPv4)
+
+Provision nodes without public IPv4 addresses for maximum cost optimization and minimum attack surface. Requires the WireGuard tunnel or VPN gateway to be active before applying.
+
+```hcl
+bootstrap_endpoint_mode    = "private_ip"
+disable_public_ipv4        = true
+kubeconfig_endpoint_mode   = "private_ip"
+talosconfig_endpoints_mode = "private_ip"
+```
+
+> [!WARNING]
+> When `disable_public_ipv4 = true`, nodes have no public IPs. All Terraform operations (bootstrap, health check, kubeconfig retrieval) use private IPs via the WireGuard tunnel or VPN gateway. Ensure your tunnel is active and reachable before applying.
 
 #### Floating IP (public VIP)
 
@@ -637,8 +719,9 @@ To upgrade your Kubernetes cluster, you must use the `talosctl upgrade-k8s` comm
 
 **Important Considerations for `talosctl` commands:**
 
-- **Talos API Endpoints:** `talosctl` talks to the Talos API (TCP/50000). Use `talosconfig_endpoints_mode = "public_ip"`
-  when running `talosctl` from outside, or `"private_ip"` when running over VPN/private networking.
+- **Talos API Endpoints:** `talosctl` talks to the Talos API (TCP/50000). Prefer `talosconfig_endpoints_mode = "public_ip"`
+  when running from outside, or `"private_ip"` over VPN/private networking. Endpoint hostname modes
+  (`"public_endpoint"` / `"private_endpoint"`) are also available for explicit gateway/proxy workflows.
 - **Avoid VIP/Load-Balanced Endpoints:** Talos recommends using direct per-node IPs as endpoints in `talosconfig` (not a
   VIP), because VIP availability depends on etcd health.
 - **Firewall Access:**

--- a/health.tf
+++ b/health.tf
@@ -3,14 +3,14 @@
 #data "talos_cluster_health" "this" {
 #  depends_on           = [data.helm_template.cilium]
 #  client_configuration = data.talos_client_configuration.this.client_configuration
-#  endpoints            = local.control_plane_public_ipv4_list
+#  endpoints            = [local.bootstrap_endpoint]
 #  control_plane_nodes  = local.control_plane_private_ipv4_list
 #  worker_nodes         = local.worker_private_ipv4_list
 #}
 
 data "http" "talos_health" {
   count    = 1
-  url      = "https://${local.control_plane_public_ipv4_list[0]}:${local.api_port_k8s}/version"
+  url      = "https://${local.bootstrap_endpoint}:${local.api_port_k8s}/version"
   insecure = true
   retry {
     attempts     = 60

--- a/network.tf
+++ b/network.tf
@@ -71,7 +71,7 @@ data "hcloud_floating_ip" "control_plane_ipv4" {
 }
 
 resource "hcloud_primary_ip" "control_plane_ipv4" {
-  count         = local.control_plane_count
+  count         = var.disable_public_ipv4 ? 0 : local.control_plane_count
   name          = "${local.cluster_prefix}control-plane-${count.index + 1}-ipv4"
   location      = data.hcloud_location.selected.name
   type          = "ipv4"
@@ -97,7 +97,7 @@ resource "hcloud_primary_ip" "control_plane_ipv6" {
 }
 
 resource "hcloud_primary_ip" "worker_ipv4" {
-  count         = local.worker_count
+  count         = var.disable_public_ipv4 ? 0 : local.worker_count
   name          = "${local.cluster_prefix}worker-${count.index + 1}-ipv4"
   location      = data.hcloud_location.selected.name
   type          = "ipv4"

--- a/server.tf
+++ b/server.tf
@@ -53,7 +53,7 @@ locals {
         local.arm_iso_id :
         local.x86_iso_id
       )
-      ipv4_public        = local.control_plane_public_ipv4_list[i - 1]
+      ipv4_public        = can(local.control_plane_public_ipv4_list[i - 1]) ? local.control_plane_public_ipv4_list[i - 1] : null
       ipv6_public        = var.enable_ipv6 ? local.control_plane_public_ipv6_list[i - 1] : null
       ipv6_public_subnet = var.enable_ipv6 ? local.control_plane_public_ipv6_subnet_list[i - 1] : null
       ipv4_private       = local.control_plane_private_ipv4_list[i - 1]
@@ -77,7 +77,7 @@ locals {
         local.arm_iso_id :
         local.x86_iso_id
       )
-      ipv4_public        = local.worker_public_ipv4_list[i - 1]
+      ipv4_public        = can(local.worker_public_ipv4_list[i - 1]) ? local.worker_public_ipv4_list[i - 1] : null
       ipv6_public        = var.enable_ipv6 ? local.worker_public_ipv6_list[i - 1] : null
       ipv6_public_subnet = var.enable_ipv6 ? local.worker_public_ipv6_subnet_list[i - 1] : null
       ipv4_private       = local.worker_private_ipv4_list[i - 1]
@@ -122,8 +122,8 @@ resource "hcloud_server" "control_planes" {
   ]
 
   public_net {
-    ipv4_enabled = true
-    ipv4         = hcloud_primary_ip.control_plane_ipv4[each.value.index].id
+    ipv4_enabled = !var.disable_public_ipv4
+    ipv4         = !var.disable_public_ipv4 ? hcloud_primary_ip.control_plane_ipv4[each.value.index].id : null
     ipv6_enabled = var.enable_ipv6
     ipv6         = var.enable_ipv6 ? hcloud_primary_ip.control_plane_ipv6[each.value.index].id : null
   }
@@ -170,8 +170,8 @@ resource "hcloud_server" "workers" {
   ]
 
   public_net {
-    ipv4_enabled = true
-    ipv4         = hcloud_primary_ip.worker_ipv4[each.value.index].id
+    ipv4_enabled = !var.disable_public_ipv4
+    ipv4         = !var.disable_public_ipv4 ? hcloud_primary_ip.worker_ipv4[each.value.index].id : null
     ipv6_enabled = var.enable_ipv6
     ipv6         = var.enable_ipv6 ? hcloud_primary_ip.worker_ipv6[each.value.index].id : null
   }

--- a/talos.tf
+++ b/talos.tf
@@ -43,6 +43,12 @@ locals {
   )
   cluster_endpoint_url_internal = "https://${local.cluster_endpoint_internal}:${local.api_port_k8s}"
 
+  bootstrap_endpoint = (
+    var.bootstrap_endpoint_mode == "private_ip" ?
+    local.control_plane_private_ipv4_list[0] :
+    can(local.control_plane_public_ipv4_list[0]) ? local.control_plane_public_ipv4_list[0] : local.control_plane_private_ipv4_list[0]
+  )
+
   // ************
   cert_SANs = distinct(
     concat(
@@ -109,8 +115,8 @@ data "talos_machine_configuration" "worker" {
 resource "talos_machine_bootstrap" "this" {
   count                = 1
   client_configuration = talos_machine_secrets.this.client_configuration
-  endpoint             = local.control_plane_public_ipv4_list[0]
-  node                 = local.control_plane_public_ipv4_list[0]
+  endpoint             = local.bootstrap_endpoint
+  node                 = local.bootstrap_endpoint
   depends_on = [
     hcloud_server.control_planes
   ]
@@ -128,6 +134,16 @@ data "talos_client_configuration" "this" {
     var.talosconfig_endpoints_mode == "public_ip" ? (
       # Use public IPs in talosconfig
       local.control_plane_public_ipv4_list
+    ) :
+
+    var.talosconfig_endpoints_mode == "public_endpoint" ? (
+      # Use a public Talos API endpoint hostname in talosconfig
+      [local.cluster_api_host_public_explicit]
+    ) :
+
+    var.talosconfig_endpoints_mode == "private_endpoint" ? (
+      # Use a private Talos API endpoint hostname in talosconfig
+      [local.cluster_api_host_private_explicit]
     ) : []
   )
 }
@@ -135,7 +151,7 @@ data "talos_client_configuration" "this" {
 resource "talos_cluster_kubeconfig" "this" {
   count                = 1
   client_configuration = talos_machine_secrets.this.client_configuration
-  node                 = local.control_plane_public_ipv4_list[0]
+  node                 = local.bootstrap_endpoint
   depends_on = [
     talos_machine_bootstrap.this
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -118,22 +118,49 @@ variable "kubeconfig_endpoint_mode" {
   EOF
 }
 
+variable "bootstrap_endpoint_mode" {
+  type    = string
+  default = "public_ip"
+  validation {
+    condition     = contains(["public_ip", "private_ip"], var.bootstrap_endpoint_mode)
+    error_message = "Invalid bootstrap_endpoint_mode. Valid values: public_ip, private_ip."
+  }
+  description = <<EOF
+    Configure how Terraform reaches Talos during bootstrap, kubeconfig retrieval, and health checks.
+
+    Values:
+    - `public_ip`: Use the first control plane public IP (default, backward compatible).
+    - `private_ip`: Use the first control plane private IP (requires VPN/private network access).
+  EOF
+}
+
 variable "talosconfig_endpoints_mode" {
   type    = string
   default = "public_ip"
   validation {
-    condition     = contains(["public_ip", "private_ip"], var.talosconfig_endpoints_mode)
-    error_message = "Invalid talosconfig_endpoints_mode. Valid values: public_ip, private_ip."
+    condition     = contains(["public_ip", "private_ip", "public_endpoint", "private_endpoint"], var.talosconfig_endpoints_mode)
+    error_message = "Invalid talosconfig_endpoints_mode. Valid values: public_ip, private_ip, public_endpoint, private_endpoint."
+  }
+  validation {
+    condition     = var.talosconfig_endpoints_mode != "public_endpoint" || var.cluster_api_host != null
+    error_message = "talosconfig_endpoints_mode = \"public_endpoint\" requires cluster_api_host to be set."
+  }
+  validation {
+    condition     = var.talosconfig_endpoints_mode != "private_endpoint" || var.cluster_api_host_private != null
+    error_message = "talosconfig_endpoints_mode = \"private_endpoint\" requires cluster_api_host_private to be set."
   }
   description = <<EOF
-    Configure which addresses are written into the generated `talosconfig` as Talos API endpoints.
+    Configure which endpoints are written into the generated `talosconfig` as Talos API endpoints.
 
-    Note: Talos recommends using direct per-node IPs as endpoints (not a VIP or load-balanced hostname), so this module
-    only supports IP lists.
+    Recommended:
+    - Prefer `public_ip` or `private_ip` (direct per-node Talos endpoints).
+    - Use endpoint hostname modes only when you intentionally proxy/load-balance Talos API traffic.
 
     Values:
     - `public_ip`: Use public IPs of all control plane nodes.
     - `private_ip`: Use private IPs of all control plane nodes.
+    - `public_endpoint`: Use `cluster_api_host` (requires it to be set).
+    - `private_endpoint`: Use `cluster_api_host_private` (requires it to be set).
   EOF
 }
 
@@ -222,6 +249,22 @@ variable "enable_ipv6" {
     If true, the servers will have an IPv6 address.
     IPv4/IPv6 dual-stack is actually not supported, it keeps being an IPv4 single stack. PRs welcome!
   EOF
+}
+
+variable "disable_public_ipv4" {
+  type        = bool
+  default     = false
+  description = <<EOF
+    If true, do not assign public IPv4 addresses to control plane and worker nodes.
+
+    Requires `bootstrap_endpoint_mode = "private_ip"` and private network reachability
+    from the Terraform runner (for example via site-to-site VPN or a bastion host).
+  EOF
+
+  validation {
+    condition     = !var.disable_public_ipv4 || var.bootstrap_endpoint_mode == "private_ip"
+    error_message = "disable_public_ipv4 requires bootstrap_endpoint_mode = \"private_ip\"."
+  }
 }
 
 variable "enable_kube_span" {


### PR DESCRIPTION
Adds `bootstrap_endpoint_mode` to let Terraform reach Talos via private IPs during bootstrap, kubeconfig retrieval, and health checks. Extends `talosconfig_endpoints_mode` with `public_endpoint`/`private_endpoint` hostname options. Adds `disable_public_ipv4` to provision nodes without public IPv4 addresses.

### Changes

**`variables.tf`**
- New: `bootstrap_endpoint_mode` (`public_ip` | `private_ip`, default `public_ip`)
- Extended: `talosconfig_endpoints_mode` now supports `public_endpoint` and `private_endpoint`
- New: `disable_public_ipv4` (default `false`, validated to require `bootstrap_endpoint_mode = "private_ip"`)

**`talos.tf`**
- New `local.bootstrap_endpoint` resolves to public or private IP per `bootstrap_endpoint_mode`
- `talos_machine_bootstrap`, `talos_cluster_kubeconfig`, and health check now use `local.bootstrap_endpoint`
- `talos_client_configuration` endpoints extended for hostname modes

**`network.tf`**
- `hcloud_primary_ip` resources conditional on `!var.disable_public_ipv4`

**`server.tf`**
- `public_net.ipv4_enabled` and `ipv4` now conditional on `!var.disable_public_ipv4`
- `ipv4_public` locals guarded with `can(...)` for empty-list safety

**`health.tf`**
- Health probe now uses `local.bootstrap_endpoint` instead of hardcoded public IP

**`README.md`**
- WireGuard VPN example for Talos-native private bootstrap
- Site-to-site VPN gateway example updated
- Fully Private (no public IPv4) example
- Private Bootstrap section in module information

### Backward compatibility

All new variables default to existing behavior (`"public_ip"`, `false`). Zero impact on existing configs.

### Tested

- WireGuard tunnel on 1-CP cluster in fsn1
- Private bootstrap plan: 3 resources switch from public to private IPs
- Full private mode plan: shows IPv4 resource destruction
- Validation errors caught for `disable_public_ipv4` without `private_ip` mode

Closes #447