### PR TITLE
fix: remove deprecated assignee_type from hcloud_primary_ip resources

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -71,12 +71,11 @@ data "hcloud_floating_ip" "control_plane_ipv4" {
 }
 
 resource "hcloud_primary_ip" "control_plane_ipv4" {
-  count         = var.disable_public_ipv4 ? 0 : local.control_plane_count
-  name          = "${local.cluster_prefix}control-plane-${count.index + 1}-ipv4"
-  location      = data.hcloud_location.selected.name
-  type          = "ipv4"
-  assignee_type = "server"
-  auto_delete   = false
+  count       = var.disable_public_ipv4 ? 0 : local.control_plane_count
+  name        = "${local.cluster_prefix}control-plane-${count.index + 1}-ipv4"
+  location    = data.hcloud_location.selected.name
+  type        = "ipv4"
+  auto_delete = false
   labels = {
     "cluster" = var.cluster_name,
     "role"    = "control-plane",
@@ -84,12 +83,11 @@ resource "hcloud_primary_ip" "control_plane_ipv4" {
 }
 
 resource "hcloud_primary_ip" "control_plane_ipv6" {
-  count         = var.enable_ipv6 ? local.control_plane_count : 0
-  name          = "${local.cluster_prefix}control-plane-${count.index + 1}-ipv6"
-  location      = data.hcloud_location.selected.name
-  type          = "ipv6"
-  assignee_type = "server"
-  auto_delete   = false
+  count       = var.enable_ipv6 ? local.control_plane_count : 0
+  name        = "${local.cluster_prefix}control-plane-${count.index + 1}-ipv6"
+  location    = data.hcloud_location.selected.name
+  type        = "ipv6"
+  auto_delete = false
   labels = {
     "cluster" = var.cluster_name,
     "role"    = "control-plane",
@@ -97,12 +95,11 @@ resource "hcloud_primary_ip" "control_plane_ipv6" {
 }
 
 resource "hcloud_primary_ip" "worker_ipv4" {
-  count         = var.disable_public_ipv4 ? 0 : local.worker_count
-  name          = "${local.cluster_prefix}worker-${count.index + 1}-ipv4"
-  location      = data.hcloud_location.selected.name
-  type          = "ipv4"
-  assignee_type = "server"
-  auto_delete   = false
+  count       = var.disable_public_ipv4 ? 0 : local.worker_count
+  name        = "${local.cluster_prefix}worker-${count.index + 1}-ipv4"
+  location    = data.hcloud_location.selected.name
+  type        = "ipv4"
+  auto_delete = false
   labels = {
     "cluster" = var.cluster_name,
     "role"    = "worker",
@@ -110,12 +107,11 @@ resource "hcloud_primary_ip" "worker_ipv4" {
 }
 
 resource "hcloud_primary_ip" "worker_ipv6" {
-  count         = var.enable_ipv6 ? local.worker_count : 0
-  name          = "${local.cluster_prefix}worker-${count.index + 1}-ipv6"
-  location      = data.hcloud_location.selected.name
-  type          = "ipv6"
-  assignee_type = "server"
-  auto_delete   = false
+  count       = var.enable_ipv6 ? local.worker_count : 0
+  name        = "${local.cluster_prefix}worker-${count.index + 1}-ipv6"
+  location    = data.hcloud_location.selected.name
+  type        = "ipv6"
+  auto_delete = false
   labels = {
     "cluster" = var.cluster_name,
     "role"    = "worker",


### PR DESCRIPTION
## Summary

The `hetznercloud/hcloud` provider deprecated the `assignee_type` attribute on `hcloud_primary_ip` — it is now optional and only required alongside `assignee_id`. None of the four `hcloud_primary_ip` resources in `network.tf` set `assignee_id`, so `assignee_type` is unused and triggers a deprecation warning on every plan/apply for every consumer of this module:

```
Warning: Unused Attribute

  with module.talos.hcloud_primary_ip.control_plane_ipv4,
  on .terraform/modules/talos/network.tf line 78, in resource "hcloud_primary_ip" "control_plane_ipv4":
  78:   assignee_type = "server"

This attribute is now optional and is only required together with the assignee_id attribute. Please remove it from your configuration.

(and 3 more similar warnings elsewhere)
```

This PR removes the four `assignee_type = "server"` lines (one per `hcloud_primary_ip` resource: `control_plane_ipv4`, `control_plane_ipv6`, `worker_ipv4`, `worker_ipv6`), which silences the warnings.

## Behavioral change

None. `assignee_type` was already optional in the absence of `assignee_id`, and these resources don't set `assignee_id`. The provider treats the attribute as no-op, hence the "Unused Attribute" warning. After removal, IPs are still created with the same lifecycle, the same `auto_delete = false` guard, and the same labels.

## Validation

End-to-end deployment on Hetzner `ash` on 2026-05-09 with these changes applied to a local module copy — single-node Talos cluster (CPX31, x86) bootstrapped successfully; primary_ipv4 created, attached to the server, and reachable; no plan-time deprecation warnings on subsequent re-plans (`Plan: 0 to add, 0 to change, 0 to destroy`).

`tofu fmt` was also run to clean up the column alignment after the line removal.

## Test plan

- [x] `tofu fmt -check network.tf` passes
- [x] `tofu plan` against an existing cluster shows no diff (resources unchanged in state)
- [x] `tofu apply` against a fresh cluster provisions IPs successfully
- [x] No deprecation warnings remain in plan/apply output (the original 4 are gone)