### PR TITLE
feat(firewall): add firewall_attachment_mode to coexist with external label-selector firewalls

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -103,4 +103,24 @@ resource "hcloud_firewall" "this" {
   labels = {
     "cluster" = var.cluster_name
   }
+
+  # Attachment mode is selectable via var.firewall_attachment_mode.
+  #
+  # - "per_server" (default, original behavior): firewall is attached via
+  #   `firewall_ids = [local.firewall_id]` on each hcloud_server.
+  #
+  # - "label_selector": firewall is attached via the apply_to block below.
+  #   Use this when you also need to attach OTHER firewalls via label selector
+  #   to the same servers (e.g., an external public-facing firewall).
+  #   Hetzner refuses per-server firewall_ids modifications once any
+  #   label-selector binding exists on the same firewall
+  #   (firewall_managed_by_label_selector), so the two modes are mutually
+  #   exclusive on the SAME firewall — but multiple label-selector firewalls
+  #   coexist freely.
+  dynamic "apply_to" {
+    for_each = var.firewall_attachment_mode == "label_selector" ? [1] : []
+    content {
+      label_selector = "cluster=${var.cluster_name}"
+    }
+  }
 }

--- a/firewall.tf
+++ b/firewall.tf
@@ -59,9 +59,9 @@ locals {
   firewall_rules = {
     for rule in local.base_firewall_rules :
     format("%s-%s-%s",
-      lookup(rule, "direction", "null"),
-      lookup(rule, "protocol", "null"),
-      lookup(rule, "port", "null")
+      coalesce(lookup(rule, "direction", "null"), "null"),
+      coalesce(lookup(rule, "protocol", "null"), "null"),
+      coalesce(lookup(rule, "port", "null"), "null")
     ) => rule
   }
 
@@ -69,9 +69,9 @@ locals {
   extra_firewall_rules = {
     for rule in var.extra_firewall_rules :
     format("%s-%s-%s",
-      lookup(rule, "direction", "null"),
-      lookup(rule, "protocol", "null"),
-      lookup(rule, "port", "null")
+      coalesce(lookup(rule, "direction", "null"), "null"),
+      coalesce(lookup(rule, "protocol", "null"), "null"),
+      coalesce(lookup(rule, "port", "null"), "null")
     ) => rule
   }
 

--- a/server.tf
+++ b/server.tf
@@ -117,9 +117,10 @@ resource "hcloud_server" "control_planes" {
     "server_type" = each.value.server_type
   }, each.value.labels)
 
-  firewall_ids = [
-    local.firewall_id
-  ]
+  # In "label_selector" mode the firewall attaches itself via apply_to
+  # (see firewall.tf), so per-server firewall_ids must stay empty to avoid
+  # the firewall_managed_by_label_selector lock.
+  firewall_ids = var.firewall_attachment_mode == "per_server" ? [local.firewall_id] : []
 
   public_net {
     ipv4_enabled = !var.disable_public_ipv4
@@ -165,9 +166,10 @@ resource "hcloud_server" "workers" {
     "server_type" = each.value.server_type
   }, each.value.labels)
 
-  firewall_ids = [
-    local.firewall_id
-  ]
+  # In "label_selector" mode the firewall attaches itself via apply_to
+  # (see firewall.tf), so per-server firewall_ids must stay empty to avoid
+  # the firewall_managed_by_label_selector lock.
+  firewall_ids = var.firewall_attachment_mode == "per_server" ? [local.firewall_id] : []
 
   public_net {
     ipv4_enabled = !var.disable_public_ipv4

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,27 @@ variable "firewall_id" {
   EOF
 }
 
+variable "firewall_attachment_mode" {
+  type        = string
+  default     = "per_server"
+  description = <<EOF
+    How the module firewall attaches to cluster servers.
+
+    - "per_server" (default, backward-compatible): attached via
+      `firewall_ids = [local.firewall_id]` on each hcloud_server.
+    - "label_selector": attached via `apply_to.label_selector` on the firewall;
+      servers receive no per-resource firewall_ids. Use this when you also need
+      to attach OTHER firewalls (e.g., an external public-facing firewall)
+      via label selector to the same servers — Hetzner refuses per-server
+      firewall_ids modifications once any label-selector binding exists on the
+      same firewall (`firewall_managed_by_label_selector`).
+  EOF
+  validation {
+    condition     = contains(["per_server", "label_selector"], var.firewall_attachment_mode)
+    error_message = "firewall_attachment_mode must be \"per_server\" or \"label_selector\"."
+  }
+}
+
 variable "firewall_use_current_ip" {
   type        = bool
   default     = false


### PR DESCRIPTION
feat(firewall): add firewall_attachment_mode to coexist with external label-selector firewalls

 
  ## Motivation

  A Hetzner firewall can attach to a server in two mutually exclusive ways:

  1. **Per-server** — `firewall_ids = [fw_id]` on the `hcloud_server`.
  2. **Label-selector** — `apply_to { label_selector = "..." }` on the firewall.

  If **both** paths exist for the same firewall+server pair, Hetzner refuses every subsequent server modification with:

  firewall_managed_by_label_selector

  This is an *ownership lock*, not a rule conflict. Today the module always uses path (1). That's fine when the module is the only firewall manager — but users who attach a **second**
  firewall (a public-facing 80/443/ICMP firewall in their own root module) via `hcloud_firewall_attachment.label_selectors` immediately trigger the lock on the module-managed firewall and
   deadlock all future applies, including `firewall_ids` modifications the module needs to make on its own servers. Recovery requires manual Hetzner-console intervention to strip the
  label-selector binding — not GitOps-friendly.

  This is a real production issue I hit on a 3-node Talos HA cluster — the symptom is `firewall_managed_by_label_selector` errors on every `tofu apply` after the second firewall enters
  the picture, with no in-code recovery path.

  ## Change

  Introduce `var.firewall_attachment_mode`:

  | Mode | Behaviour |
  |---|---|
  | `"per_server"` (default) | **Unchanged from current behaviour** — `firewall_ids = [local.firewall_id]` on each server. Full backward compat. |
  | `"label_selector"` | Module firewall gets `apply_to.label_selector = "cluster=<name>"`; servers have `firewall_ids = []`. |

  Multiple label-selector attachments on the same servers coexist freely (the lock only triggers when mixing the two modes on the *same* firewall), so external label-selector firewalls no
   longer conflict.

  ## Backward compatibility

  - New variable, defaults to `"per_server"` → existing users see no behavioural change.
  - No removed variables, no renamed resources, no state migration needed.
  - Validated against the two allowed values; typos fail fast at plan time.

  ## Drive-by fix

  Second commit (`fix(firewall): handle null port in extra_firewall_rules deduplication key`) addresses an independent latent bug: `extra_firewall_rules` with `port = null` (legitimate
  for ICMP/ESP/GRE/AH) causes `format("%s", null)` to fail in the dedup-key locals. Wrapping each `lookup()` in `coalesce(..., "null")` matches the original default-arg intent. Happy to
  split into a separate PR if you'd prefer.

  ## Testing

  Tested on a live 3-node Talos cluster on Hetzner (cax11/cx23, nbg1):
  - `per_server` mode: byte-identical plan vs. current `main` for an existing cluster (zero diff).
  - `label_selector` mode + an external `hcloud_firewall_attachment` with `label_selectors`: both firewalls bind to all servers, `firewall_managed_by_label_selector` no longer triggers on
   subsequent applies.

  `terraform fmt`, `terraform validate` clean. Pre-commit hooks pass.
