### PR TITLE
fix: add lazy_load config to kubectl provider

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -53,5 +53,6 @@ provider "kubectl" {
   client_key             = local.kubeconfig_data.client_key
   cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
   load_config_file       = false
+  lazy_load              = true
   apply_retry_count      = 3
 }


### PR DESCRIPTION
Encountering 

```
invalid provider configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

when trying to use this terraform module. 

Some digging into the kubectl provider shows some changed behavior where kubeconfigs now default to being eager loaded instead of lazy loaded. I believe this is what is causing the failure I am observing, since a cluster hasn't yet been created and no kubeconfig exists yet.

Reference for the issue in the kubectl provider: https://github.com/alekc/terraform-provider-kubectl/issues/283